### PR TITLE
Add support for custom CURL options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "infobip/infobip-api-php-client",
   "description": "Infobip SMS library for PHP",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "keywords": [
     "infobip",
     "sms",
@@ -14,6 +14,10 @@
     {
       "name": "",
       "email": "libraries@infobip.com"
+    },
+    {
+      "name": "Tariq86",
+      "email": "tariq.86@protonmail.com"
     }
   ],
   "support": {
@@ -22,7 +26,7 @@
   "license": "Apache-2.0",
   "minimum-stability": "dev",
   "require": {
-    "netresearch/jsonmapper": "0.9.0"
+    "netresearch/jsonmapper": "2.1.0"
   },
   "autoload": {
     "psr-4": {

--- a/infobip/api/AbstractApiClient.php
+++ b/infobip/api/AbstractApiClient.php
@@ -11,11 +11,40 @@ class AbstractApiClient
     const VERSION = '1.1.3';
     private $configuration;
     private $mapper;
+    private $curlOpts;
 
     public function __construct($configuration)
     {
         $this->configuration = $configuration;
         $this->mapper = new JsonMapper();
+        $this->curlOpts = array(
+            CURLOPT_FRESH_CONNECT => 1,
+            CURLOPT_CONNECTTIMEOUT => 60,
+            CURLOPT_TIMEOUT => 120,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS => 3,
+            CURLOPT_USERAGENT => 'Php-Client-Library-' . self::VERSION,
+        );
+    }
+
+    /**
+     * Set the given curl option to the given value
+     * @param $curlOpt
+     * @param $curlOptValue
+    */
+    public function setCurlOpt($curlOpt, $curlOptValue)
+    {
+        $this->curlOpts[$curlOpt] = $curlOptValue;
+    }
+
+	/**
+	 * Get all currently-configured curl options
+	 * @return array
+	 */
+    public function getCurlOpts()
+    {
+        return $this->curlOpts;
     }
 
     protected function executeGET($restPath, $params)
@@ -85,18 +114,10 @@ class AbstractApiClient
             $url .= '?' . $this->buildQuery($queryParams);
         }
 
-        $opts = array(
-            CURLOPT_FRESH_CONNECT => 1,
-            CURLOPT_CONNECTTIMEOUT => 60,
-            CURLOPT_TIMEOUT => 120,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_MAXREDIRS => 3,
-            CURLOPT_USERAGENT => 'Php-Client-Library-' . self::VERSION,
-            CURLOPT_CUSTOMREQUEST => $httpMethod,
-            CURLOPT_URL => $url,
-            CURLOPT_HTTPHEADER => $sendHeaders
-        );
+        $opts = $this->getCurlOpts();
+        $opts[CURLOPT_CUSTOMREQUEST] = $httpMethod;
+        $opts[CURLOPT_URL] = $url;
+        $opts[CURLOPT_HTTPHEADER] = $sendHeaders;
 
         if ($this->configuration) {
             $opts[CURLOPT_HTTPHEADER][] = 'Authorization: ' . $this->configuration->getAuthenticationHeader();

--- a/infobip/api/AbstractApiClient.php
+++ b/infobip/api/AbstractApiClient.php
@@ -29,9 +29,9 @@ class AbstractApiClient
     }
 
     /**
-     * Set the given curl option to the given value
-     * @param $curlOpt
-     * @param $curlOptValue
+     * Set the given cURL option to the given value
+     * @param int $curlOpt a valid cURL option; @see https://www.php.net/manual/en/function.curl-setopt.php
+     * @param mixed $curlOptValue the desired value for the given cURL option
     */
     public function setCurlOpt($curlOpt, $curlOptValue)
     {
@@ -39,7 +39,7 @@ class AbstractApiClient
     }
 
 	/**
-	 * Get all currently-configured curl options
+	 * Get all currently-configured cURL options
 	 * @return array
 	 */
     public function getCurlOpts()


### PR DESCRIPTION
### Overview
A recent integration with this package required that I customize the curl options that are used when performing the API request, so I made the following changes to the `AbstractApiClient` class to make this possible:
 * Move in-line curl options array (`$opts`) to private class property `$curlOpts`
 * Initialize the new `$curlOpts` property in the constructor with all default/global curl options
 * Add public method `AbstractApiClient->setCurlOpt($curlOpt, $curlOptValue)` to allow library users to set custom curl options
 * Add public method `AbstractApiClient->getCurlOpts()` to get an array of the currently-set curl options

### Testing Done
I made a few test API calls with additional curl options set via the new method, as well as without to ensure that the default behavior is unchanged.

### Additional Information
All of the curl options that are currently being set are still being mapped to the same values that they were before, so there are no changes to the current/default behavior. In other words, this PR will not introduce any changes to the current curl call, unless the user of the package explicitly calls the new `setCurlOpts(...)` method.