### PR TITLE
Updated jsonmapper version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "minimum-stability": "dev",
   "require": {
-    "netresearch/jsonmapper": "0.9.0"
+    "netresearch/jsonmapper": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
* This fixes deprecations notices raised from older versions of jsonmapper, which have been fixed in later versions

* Current dependency on v0.9.0 of jsonmapper released in 2015 is missing many updates which fix deprecations in later version of php7.4

* As the package doesn't have tests, i have done tests by using this branch on one of my current projects. So far I haven't run into any breaking changes from this update. 

* Further review is welcome.