### PR TITLE
Update to version 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the library will be documented in this file.
 
 The format of the file is based on [Keep a Changelog](http://keepachangelog.com/) and this library adheres to [Semantic Versioning](http://semver.org/) as mentioned in the [README.md][readme] file.
 
+
+## [ [6.1.0](https://github.com/infobip/infobip-api-php-client/releases/tag/6.1.0) ] - 2024-12-09
+
+### Added
+* Support for [Infobip Moments](https://www.infobip.com/docs/api/customer-engagement/moments).
+
+### Changed
+* Removed no longer supported 50 business-initiated conversations messaging tear limit for WhatsApp senders.
+* Added `createdAt` and `lastUpdatedAt` fields to WhatsApp Template response models.
+* Added new Calls error code type: `MACHINE_DETECTED`.
+* `CallRoutingWebRtcEndpoint` now allows using default `to` value used in inbound call as an identity.
+* Refactored a part of Calls API tests.
+
+### Fixed
+* IVR scenario action scripts types.
+
 ## [ [6.0.0](https://github.com/infobip/infobip-api-php-client/releases/tag/6.0.0) ] - 2024-12-09
 
 ⚠️ **IMPORTANT NOTE:** This release contains breaking changes! From this point onward PHP version 8.0 is no longer supported. Minimum PHP version required is 8.3.
@@ -38,7 +54,7 @@ version required is 7.0.
   * Added a content field within `SmsMessage` to define the message content.
     This supports both textual and binary messages, which can be created using [SmsTextContent](Infobip/Model/SmsTextContent.php) or [SmsBinaryContent](Infobip/Model/SmsBinaryContent.php), respectively.
   * Unified request classes by replacing `SmsAdvancedTextualRequest` and `SmsAdvancedBinaryRequest` with the new [SmsRequest](Infobip/Model/SmsRequest.php) class.
-  * Consolidated sending functions: use `sendSmsMessages` instead of the `sendSmsMessage` and `sendBinarySmsMessage` functions. 
+  * Consolidated sending functions: use `sendSmsMessages` instead of the `sendSmsMessage` and `sendBinarySmsMessage` functions.
 * Across all Call models, the `applicationId` field has been removed and replaced with the `platform` field, as encapsulates platform fields and reflects the current state of the endpoint.
   In addition to that, a new required `callsConfigurationId` field has been added.
 * Removed delivery time window configuration classes (`SmsDeliveryTimeWindow`, `MmsDeliveryTimeWindow`, `ViberDeliveryTimeWindow`, `CallRoutingAllowedTimeWindow`, `CallsDeliveryTimeWindow`, `SmsDeliveryTimeWindow`, `CallsTimeWindow`) in favor of a unified class: [DeliveryTimeWindow](Infobip/Model/DeliveryTimeWindow.php)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the library will be documented in this file.
 The format of the file is based on [Keep a Changelog](http://keepachangelog.com/) and this library adheres to [Semantic Versioning](http://semver.org/) as mentioned in the [README.md][readme] file.
 
 
-## [ [6.1.0](https://github.com/infobip/infobip-api-php-client/releases/tag/6.1.0) ] - 2024-12-09
+## [ [6.1.0](https://github.com/infobip/infobip-api-php-client/releases/tag/6.1.0) ] - 2024-12-16
 
 ### Added
 * Support for [Infobip Moments](https://www.infobip.com/docs/api/customer-engagement/moments).

--- a/Infobip/Api/FlowApi.php
+++ b/Infobip/Api/FlowApi.php
@@ -1,0 +1,973 @@
+<?php
+
+// phpcs:ignorefile
+
+/**
+ * FlowApi
+ * PHP version 8.3
+ *
+ * @category Class
+ * @package  Infobip
+ * @author   Infobip Support
+ * @link     https://www.infobip.com
+ */
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Request;
+use Infobip\ApiException;
+use Infobip\Configuration;
+use Infobip\DeprecationChecker;
+use Infobip\ObjectSerializer;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class FlowApi
+{
+    use ApiTrait;
+
+    private Configuration $config;
+    private ClientInterface $client;
+    private ObjectSerializer $objectSerializer;
+    private LoggerInterface $logger;
+    private DeprecationChecker $deprecationChecker;
+
+    /**
+     * @param Configuration $config - Client configuration
+     * @param ClientInterface|null $client - (Optional) The HTTP client with Guzzle as default
+     * @param ObjectSerializer|null $objectSerializer - (Optional) The object serializer
+     * @param LoggerInterface|null $logger - (Optional) The logger used for API deprecations
+     * @param DeprecationChecker|null $deprecationChecker (Optional) API deprecation checker that will log deprecations
+     */
+    public function __construct(
+        Configuration $config,
+        ?ClientInterface $client = null,
+        ?ObjectSerializer $objectSerializer = null,
+        ?LoggerInterface $logger = null,
+        ?DeprecationChecker $deprecationChecker = null
+    ) {
+        $this->config = $config;
+        $this->client = $client ?: new Client();
+        $this->objectSerializer = $objectSerializer ?: new ObjectSerializer();
+        $this->logger = $logger ?: new NullLogger();
+        $this->deprecationChecker = $deprecationChecker ?: new DeprecationChecker($this->logger);
+    }
+
+    /**
+     * Operation addFlowParticipants
+     *
+     * Add participants to flow
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest flowAddFlowParticipantsRequest (required)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FlowAddFlowParticipantsResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function addFlowParticipants(int $campaignId, \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest)
+    {
+        $request = $this->addFlowParticipantsRequest($campaignId, $flowAddFlowParticipantsRequest);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->addFlowParticipantsResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->addFlowParticipantsApiException($exception);
+        }
+    }
+
+    /**
+     * Operation addFlowParticipantsAsync
+     *
+     * Add participants to flow
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function addFlowParticipantsAsync(int $campaignId, \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest): PromiseInterface
+    {
+        $request = $this->addFlowParticipantsRequest($campaignId, $flowAddFlowParticipantsRequest);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->addFlowParticipantsResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->addFlowParticipantsApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'addFlowParticipants'
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function addFlowParticipantsRequest(int $campaignId, \Infobip\Model\FlowAddFlowParticipantsRequest $flowAddFlowParticipantsRequest): Request
+    {
+        $allData = [
+             'campaignId' => $campaignId,
+             'flowAddFlowParticipantsRequest' => $flowAddFlowParticipantsRequest,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'campaignId' => [
+                        new Assert\NotBlank(),
+                    ],
+                    'flowAddFlowParticipantsRequest' => [
+                        new Assert\NotNull(),
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/moments/1/flows/{campaignId}/participants';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // path params
+        if ($campaignId !== null) {
+            $resourcePath = str_replace(
+                '{' . 'campaignId' . '}',
+                $this->objectSerializer->toPathValue($campaignId),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (isset($flowAddFlowParticipantsRequest)) {
+            $httpBody = ($headers['Content-Type'] === 'application/json')
+                ? $this->objectSerializer->serialize($flowAddFlowParticipantsRequest)
+                : $flowAddFlowParticipantsRequest;
+        } elseif (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'addFlowParticipants'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FlowAddFlowParticipantsResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function addFlowParticipantsResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FlowAddFlowParticipantsResponse', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'addFlowParticipants'
+     */
+    private function addFlowParticipantsApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 400) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\FlowExceptionResponse',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 429) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+    /**
+     * Operation getFlowParticipantsAddedReport
+     *
+     * Get a report on participants added to flow
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param string $operationId Unique identifier of the operation. (required)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FlowParticipantsReportResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function getFlowParticipantsAddedReport(int $campaignId, string $operationId)
+    {
+        $request = $this->getFlowParticipantsAddedReportRequest($campaignId, $operationId);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->getFlowParticipantsAddedReportResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->getFlowParticipantsAddedReportApiException($exception);
+        }
+    }
+
+    /**
+     * Operation getFlowParticipantsAddedReportAsync
+     *
+     * Get a report on participants added to flow
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param string $operationId Unique identifier of the operation. (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getFlowParticipantsAddedReportAsync(int $campaignId, string $operationId): PromiseInterface
+    {
+        $request = $this->getFlowParticipantsAddedReportRequest($campaignId, $operationId);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->getFlowParticipantsAddedReportResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->getFlowParticipantsAddedReportApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getFlowParticipantsAddedReport'
+     *
+     * @param int $campaignId Unique identifier of the flow that participant will be added to. (required)
+     * @param string $operationId Unique identifier of the operation. (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function getFlowParticipantsAddedReportRequest(int $campaignId, string $operationId): Request
+    {
+        $allData = [
+             'campaignId' => $campaignId,
+             'operationId' => $operationId,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'campaignId' => [
+                        new Assert\NotBlank(),
+                    ],
+                    'operationId' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/moments/1/flows/{campaignId}/participants/report';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // query params
+        if ($operationId !== null) {
+            $queryParams['operationId'] = $operationId;
+        }
+
+        // path params
+        if ($campaignId !== null) {
+            $resourcePath = str_replace(
+                '{' . 'campaignId' . '}',
+                $this->objectSerializer->toPathValue($campaignId),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'getFlowParticipantsAddedReport'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FlowParticipantsReportResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function getFlowParticipantsAddedReportResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FlowParticipantsReportResponse', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'getFlowParticipantsAddedReport'
+     */
+    private function getFlowParticipantsAddedReportApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 429) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+    /**
+     * Operation removePeopleFromFlow
+     *
+     * Remove person from flow
+     *
+     * @param int $campaignId Unique identifier of the flow that person will be removed from. (required)
+     * @param null|string $phone Person&#39;s phone number. (optional)
+     * @param null|string $email Person&#39;s email address. (optional)
+     * @param null|string $externalId Unique ID for the person from an external system. (optional)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    public function removePeopleFromFlow(int $campaignId, ?string $phone = null, ?string $email = null, ?string $externalId = null)
+    {
+        $request = $this->removePeopleFromFlowRequest($campaignId, $phone, $email, $externalId);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->removePeopleFromFlowResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->removePeopleFromFlowApiException($exception);
+        }
+    }
+
+    /**
+     * Operation removePeopleFromFlowAsync
+     *
+     * Remove person from flow
+     *
+     * @param int $campaignId Unique identifier of the flow that person will be removed from. (required)
+     * @param null|string $phone Person&#39;s phone number. (optional)
+     * @param null|string $email Person&#39;s email address. (optional)
+     * @param null|string $externalId Unique ID for the person from an external system. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function removePeopleFromFlowAsync(int $campaignId, ?string $phone = null, ?string $email = null, ?string $externalId = null): PromiseInterface
+    {
+        $request = $this->removePeopleFromFlowRequest($campaignId, $phone, $email, $externalId);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->removePeopleFromFlowResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->removePeopleFromFlowApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'removePeopleFromFlow'
+     *
+     * @param int $campaignId Unique identifier of the flow that person will be removed from. (required)
+     * @param null|string $phone Person&#39;s phone number. (optional)
+     * @param null|string $email Person&#39;s email address. (optional)
+     * @param null|string $externalId Unique ID for the person from an external system. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function removePeopleFromFlowRequest(int $campaignId, ?string $phone = null, ?string $email = null, ?string $externalId = null): Request
+    {
+        $allData = [
+             'campaignId' => $campaignId,
+             'phone' => $phone,
+             'email' => $email,
+             'externalId' => $externalId,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'campaignId' => [
+                        new Assert\NotBlank(),
+                    ],
+                    'phone' => [
+                    ],
+                    'email' => [
+                    ],
+                    'externalId' => [
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/communication/1/flows/{campaignId}/participants';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // query params
+        if ($phone !== null) {
+            $queryParams['phone'] = $phone;
+        }
+
+        // query params
+        if ($email !== null) {
+            $queryParams['email'] = $email;
+        }
+
+        // query params
+        if ($externalId !== null) {
+            $queryParams['externalId'] = $externalId;
+        }
+
+        // path params
+        if ($campaignId !== null) {
+            $resourcePath = str_replace(
+                '{' . 'campaignId' . '}',
+                $this->objectSerializer->toPathValue($campaignId),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'DELETE',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'removePeopleFromFlow'
+     * @throws ApiException on non-2xx response
+     * @return null
+     */
+    private function removePeopleFromFlowResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'removePeopleFromFlow'
+     */
+    private function removePeopleFromFlowApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 400) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\FlowExceptionResponse',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\FlowExceptionResponse',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 429) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+}

--- a/Infobip/Api/FormsApi.php
+++ b/Infobip/Api/FormsApi.php
@@ -1,0 +1,1209 @@
+<?php
+
+// phpcs:ignorefile
+
+/**
+ * FormsApi
+ * PHP version 8.3
+ *
+ * @category Class
+ * @package  Infobip
+ * @author   Infobip Support
+ * @link     https://www.infobip.com
+ */
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Request;
+use Infobip\ApiException;
+use Infobip\Configuration;
+use Infobip\DeprecationChecker;
+use Infobip\ObjectSerializer;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class FormsApi
+{
+    use ApiTrait;
+
+    private Configuration $config;
+    private ClientInterface $client;
+    private ObjectSerializer $objectSerializer;
+    private LoggerInterface $logger;
+    private DeprecationChecker $deprecationChecker;
+
+    /**
+     * @param Configuration $config - Client configuration
+     * @param ClientInterface|null $client - (Optional) The HTTP client with Guzzle as default
+     * @param ObjectSerializer|null $objectSerializer - (Optional) The object serializer
+     * @param LoggerInterface|null $logger - (Optional) The logger used for API deprecations
+     * @param DeprecationChecker|null $deprecationChecker (Optional) API deprecation checker that will log deprecations
+     */
+    public function __construct(
+        Configuration $config,
+        ?ClientInterface $client = null,
+        ?ObjectSerializer $objectSerializer = null,
+        ?LoggerInterface $logger = null,
+        ?DeprecationChecker $deprecationChecker = null
+    ) {
+        $this->config = $config;
+        $this->client = $client ?: new Client();
+        $this->objectSerializer = $objectSerializer ?: new ObjectSerializer();
+        $this->logger = $logger ?: new NullLogger();
+        $this->deprecationChecker = $deprecationChecker ?: new DeprecationChecker($this->logger);
+    }
+
+    /**
+     * Operation getForm
+     *
+     * Get form
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FormsResponseContent|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function getForm(string $id)
+    {
+        $request = $this->getFormRequest($id);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->getFormResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->getFormApiException($exception);
+        }
+    }
+
+    /**
+     * Operation getFormAsync
+     *
+     * Get form
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getFormAsync(string $id): PromiseInterface
+    {
+        $request = $this->getFormRequest($id);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->getFormResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->getFormApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getForm'
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function getFormRequest(string $id): Request
+    {
+        $allData = [
+             'id' => $id,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'id' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/forms/1/forms/{id}';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // path params
+        if ($id !== null) {
+            $resourcePath = str_replace(
+                '{' . 'id' . '}',
+                $this->objectSerializer->toPathValue($id),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'getForm'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FormsResponseContent|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function getFormResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FormsResponseContent', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'getForm'
+     */
+    private function getFormApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+    /**
+     * Operation getForms
+     *
+     * Get forms
+     *
+     * @param int $offset Skip first {offset} forms of the list. (optional, default to 0)
+     * @param int $limit The maximum number of returned forms. Maximum value is &#x60;100&#x60;. (optional, default to 25)
+     * @param null|\Infobip\Model\FormsType $formType The type of returned forms. (optional)
+     * @param null|\Infobip\Model\FormsStatus $formStatus The status of returned forms. (optional)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FormsResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function getForms(int $offset = 0, int $limit = 25, ?\Infobip\Model\FormsType $formType = null, ?\Infobip\Model\FormsStatus $formStatus = null)
+    {
+        $request = $this->getFormsRequest($offset, $limit, $formType, $formStatus);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->getFormsResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->getFormsApiException($exception);
+        }
+    }
+
+    /**
+     * Operation getFormsAsync
+     *
+     * Get forms
+     *
+     * @param int $offset Skip first {offset} forms of the list. (optional, default to 0)
+     * @param int $limit The maximum number of returned forms. Maximum value is &#x60;100&#x60;. (optional, default to 25)
+     * @param null|\Infobip\Model\FormsType $formType The type of returned forms. (optional)
+     * @param null|\Infobip\Model\FormsStatus $formStatus The status of returned forms. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getFormsAsync(int $offset = 0, int $limit = 25, ?\Infobip\Model\FormsType $formType = null, ?\Infobip\Model\FormsStatus $formStatus = null): PromiseInterface
+    {
+        $request = $this->getFormsRequest($offset, $limit, $formType, $formStatus);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->getFormsResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->getFormsApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getForms'
+     *
+     * @param int $offset Skip first {offset} forms of the list. (optional, default to 0)
+     * @param int $limit The maximum number of returned forms. Maximum value is &#x60;100&#x60;. (optional, default to 25)
+     * @param null|\Infobip\Model\FormsType $formType The type of returned forms. (optional)
+     * @param null|\Infobip\Model\FormsStatus $formStatus The status of returned forms. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function getFormsRequest(int $offset = 0, int $limit = 25, ?\Infobip\Model\FormsType $formType = null, ?\Infobip\Model\FormsStatus $formStatus = null): Request
+    {
+        $allData = [
+             'offset' => $offset,
+             'limit' => $limit,
+             'formType' => $formType,
+             'formStatus' => $formStatus,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'offset' => [
+                    ],
+                    'limit' => [
+                    ],
+                    'formType' => [
+                    ],
+                    'formStatus' => [
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/forms/1/forms';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // query params
+        if ($offset !== null) {
+            $queryParams['offset'] = $offset;
+        }
+
+        // query params
+        if ($limit !== null) {
+            $queryParams['limit'] = $limit;
+        }
+
+        // query params
+        if ($formType !== null) {
+            $queryParams['formType'] = $formType;
+        }
+
+        // query params
+        if ($formStatus !== null) {
+            $queryParams['formStatus'] = $formStatus;
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'getForms'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FormsResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function getFormsResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FormsResponse', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'getForms'
+     */
+    private function getFormsApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 400) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+    /**
+     * Operation incrementViewCount
+     *
+     * Increment form view count
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FormsStatusResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function incrementViewCount(string $id)
+    {
+        $request = $this->incrementViewCountRequest($id);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->incrementViewCountResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->incrementViewCountApiException($exception);
+        }
+    }
+
+    /**
+     * Operation incrementViewCountAsync
+     *
+     * Increment form view count
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function incrementViewCountAsync(string $id): PromiseInterface
+    {
+        $request = $this->incrementViewCountRequest($id);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->incrementViewCountResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->incrementViewCountApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'incrementViewCount'
+     *
+     * @param string $id ID of a form (required)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function incrementViewCountRequest(string $id): Request
+    {
+        $allData = [
+             'id' => $id,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'id' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/forms/1/forms/{id}/views';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // path params
+        if ($id !== null) {
+            $resourcePath = str_replace(
+                '{' . 'id' . '}',
+                $this->objectSerializer->toPathValue($id),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'incrementViewCount'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FormsStatusResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function incrementViewCountResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FormsStatusResponse', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'incrementViewCount'
+     */
+    private function incrementViewCountApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+    /**
+     * Operation submitFormData
+     *
+     * Submit form data
+     *
+     * @param string $id ID of a form (required)
+     * @param array<string,mixed> $requestBody Form Data (required)
+     * @param null|string $ibSubmissionSource By sending source information you will be able to see Analytics by Source – It reflects the submission rates by source if your form is present in numerous places. (optional)
+     * @param null|string $ibSubmissionFormCampaign By sending campaign information you will be able to see Analytics by Campaign – It reflects the submission rates by campaign if your form is included in multiple campaigns. (optional)
+     *
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
+     * @return \Infobip\Model\FormsStatusResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException
+     */
+    public function submitFormData(string $id, array $requestBody, ?string $ibSubmissionSource = null, ?string $ibSubmissionFormCampaign = null)
+    {
+        $request = $this->submitFormDataRequest($id, $requestBody, $ibSubmissionSource, $ibSubmissionFormCampaign);
+
+        try {
+            try {
+                $response = $this->client->send($request);
+                $this->deprecationChecker->check($request, $response);
+                return $this->submitFormDataResponse($response, $request->getUri());
+            } catch (GuzzleException $exception) {
+                $errorResponse = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                throw new ApiException(
+                    "[{$exception->getCode()}] {$exception->getMessage()}",
+                    $exception->getCode(),
+                    $errorResponse?->getHeaders(),
+                    ($errorResponse !== null) ? (string)$errorResponse->getBody() : null
+                );
+            }
+        } catch (ApiException $exception) {
+            throw $this->submitFormDataApiException($exception);
+        }
+    }
+
+    /**
+     * Operation submitFormDataAsync
+     *
+     * Submit form data
+     *
+     * @param string $id ID of a form (required)
+     * @param array<string,mixed> $requestBody Form Data (required)
+     * @param null|string $ibSubmissionSource By sending source information you will be able to see Analytics by Source – It reflects the submission rates by source if your form is present in numerous places. (optional)
+     * @param null|string $ibSubmissionFormCampaign By sending campaign information you will be able to see Analytics by Campaign – It reflects the submission rates by campaign if your form is included in multiple campaigns. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    public function submitFormDataAsync(string $id, array $requestBody, ?string $ibSubmissionSource = null, ?string $ibSubmissionFormCampaign = null): PromiseInterface
+    {
+        $request = $this->submitFormDataRequest($id, $requestBody, $ibSubmissionSource, $ibSubmissionFormCampaign);
+
+        return $this
+            ->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($request) {
+                    $this->deprecationChecker->check($request, $response);
+                    return $this->submitFormDataResponse($response, $request->getUri());
+                },
+                function (GuzzleException $exception) {
+                    $statusCode = $exception->getCode();
+
+                    $response = ($exception instanceof RequestException) ? $exception->getResponse() : null;
+
+                    $exception = new ApiException(
+                        "[{$statusCode}] {$exception->getMessage()}",
+                        $statusCode,
+                        $response?->getHeaders(),
+                        ($response !== null) ? (string)$response->getBody() : null
+                    );
+
+                    throw $this->submitFormDataApiException($exception);
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'submitFormData'
+     *
+     * @param string $id ID of a form (required)
+     * @param array<string,mixed> $requestBody Form Data (required)
+     * @param null|string $ibSubmissionSource By sending source information you will be able to see Analytics by Source – It reflects the submission rates by source if your form is present in numerous places. (optional)
+     * @param null|string $ibSubmissionFormCampaign By sending campaign information you will be able to see Analytics by Campaign – It reflects the submission rates by campaign if your form is included in multiple campaigns. (optional)
+     *
+     * @throws InvalidArgumentException
+     */
+    private function submitFormDataRequest(string $id, array $requestBody, ?string $ibSubmissionSource = null, ?string $ibSubmissionFormCampaign = null): Request
+    {
+        $allData = [
+             'id' => $id,
+             'requestBody' => $requestBody,
+             'ibSubmissionSource' => $ibSubmissionSource,
+             'ibSubmissionFormCampaign' => $ibSubmissionFormCampaign,
+        ];
+
+        $validationConstraints = new Assert\Collection(
+            fields : [
+                    'id' => [
+                        new Assert\NotBlank(),
+                    ],
+                    'requestBody' => [
+                        new Assert\NotNull(),
+                    ],
+                    'ibSubmissionSource' => [
+                    ],
+                    'ibSubmissionFormCampaign' => [
+                    ],
+                ]
+        );
+
+        $this->validateParams($allData, $validationConstraints);
+        $resourcePath = '/forms/1/forms/{id}/data';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+
+        // header params
+        if ($ibSubmissionSource !== null) {
+            $headerParams['ib-submission-source'] = $this->objectSerializer->toHeaderValue($ibSubmissionSource);
+        }
+
+        // header params
+        if ($ibSubmissionFormCampaign !== null) {
+            $headerParams['ib-submission-form-campaign'] = $this->objectSerializer->toHeaderValue($ibSubmissionFormCampaign);
+        }
+
+        // path params
+        if ($id !== null) {
+            $resourcePath = str_replace(
+                '{' . 'id' . '}',
+                $this->objectSerializer->toPathValue($id),
+                $resourcePath
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ];
+
+        // for model (json/xml)
+        if (isset($requestBody)) {
+            $httpBody = ($headers['Content-Type'] === 'application/json')
+                ? $this->objectSerializer->serialize($requestBody)
+                : $requestBody;
+        } elseif (count($formParams) > 0) {
+            if ($headers['Content-Type'] === 'multipart/form-data') {
+                $boundary = '----' . hash('sha256', uniqid('', true));
+                $headers['Content-Type'] .= '; boundary=' . $boundary;
+                $multipartContents = [];
+
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = (\is_array($formParamValue)) ? $formParamValue : [$formParamValue];
+
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents, $boundary);
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = $this->objectSerializer->serialize($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = Query::build($formParams);
+            }
+        }
+
+        $apiKey = $this->config->getApiKey();
+
+        if ($apiKey !== null) {
+            $headers[$this->config->getApiKeyHeader()] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = \array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        foreach ($queryParams as $key => $value) {
+            if (\is_array($value)) {
+                continue;
+            }
+
+            $queryParams[$key] = $this->objectSerializer->toString($value);
+        }
+
+        $query = Query::build($queryParams);
+
+        return new Request(
+            'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create response for operation 'submitFormData'
+     * @throws ApiException on non-2xx response
+     * @return \Infobip\Model\FormsStatusResponse|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|\Infobip\Model\ApiException|null
+     */
+    private function submitFormDataResponse(ResponseInterface $response, UriInterface $requestUri): mixed
+    {
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
+        $responseHeaders = $response->getHeaders();
+
+        if ($statusCode < 200 || $statusCode > 299) {
+            throw new ApiException(
+                sprintf('[%d] API Error (%s)', $statusCode, $requestUri),
+                $statusCode,
+                $responseHeaders,
+                $responseBody
+            );
+        }
+
+        $responseResult = null;
+
+        if ($statusCode === 200) {
+            $responseResult = $this->deserialize($responseBody, '\Infobip\Model\FormsStatusResponse', $responseHeaders);
+        }
+        return $responseResult;
+    }
+
+    /**
+     * Adapt given ApiException for operation 'submitFormData'
+     */
+    private function submitFormDataApiException(ApiException $apiException): ApiException
+    {
+        $statusCode = $apiException->getCode();
+
+        if ($statusCode === 400) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 401) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 403) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 404) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 429) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+        if ($statusCode === 500) {
+            $data = $this->objectSerializer->deserialize(
+                $apiException->getResponseBody(),
+                '\Infobip\Model\ApiException',
+                $apiException->getResponseHeaders()
+            );
+
+            $apiException->setResponseObject($data);
+
+            return $apiException;
+        }
+
+        return $apiException;
+    }
+
+}

--- a/Infobip/Configuration.php
+++ b/Infobip/Configuration.php
@@ -56,7 +56,7 @@ final class Configuration
 
     public function getUserAgent(): string
     {
-        return 'infobip-api-client-php/6.0.0/PHP';
+        return 'infobip-api-client-php/6.1.0/PHP';
     }
 
     public function getTempFolderPath(): string

--- a/Infobip/EnumNormalizer.php
+++ b/Infobip/EnumNormalizer.php
@@ -29,8 +29,8 @@ use Infobip\Model\EnumInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
 {

--- a/Infobip/Model/ApiErrorResource.php
+++ b/Infobip/Model/ApiErrorResource.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ApiErrorResource
 {
     /**

--- a/Infobip/Model/ApiErrorViolation.php
+++ b/Infobip/Model/ApiErrorViolation.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ApiErrorViolation
 {
     /**

--- a/Infobip/Model/ApiRequestErrorDetails.php
+++ b/Infobip/Model/ApiRequestErrorDetails.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ApiRequestErrorDetails
 {
     /**

--- a/Infobip/Model/Call.php
+++ b/Infobip/Model/Call.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class Call
 {

--- a/Infobip/Model/CallBulkResponse.php
+++ b/Infobip/Model/CallBulkResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallBulkResponse
 {
     /**

--- a/Infobip/Model/CallLog.php
+++ b/Infobip/Model/CallLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallLog
 {

--- a/Infobip/Model/CallRate.php
+++ b/Infobip/Model/CallRate.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRate
 {
     /**

--- a/Infobip/Model/CallRecording.php
+++ b/Infobip/Model/CallRecording.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallRecording
 {

--- a/Infobip/Model/CallRoutingCriteria.php
+++ b/Infobip/Model/CallRoutingCriteria.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PHONE" => "\Infobip\Model\CallRoutingPhoneCriteria",

--- a/Infobip/Model/CallRoutingDestination.php
+++ b/Infobip/Model/CallRoutingDestination.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "ENDPOINT" => "\Infobip\Model\CallRoutingEndpointDestination",

--- a/Infobip/Model/CallRoutingEndpoint.php
+++ b/Infobip/Model/CallRoutingEndpoint.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PHONE" => "\Infobip\Model\CallRoutingPhoneEndpoint",

--- a/Infobip/Model/CallRoutingPhoneCriteria.php
+++ b/Infobip/Model/CallRoutingPhoneCriteria.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRoutingPhoneCriteria extends CallRoutingCriteria
 {
     public const TYPE = 'PHONE';

--- a/Infobip/Model/CallRoutingPhoneEndpoint.php
+++ b/Infobip/Model/CallRoutingPhoneEndpoint.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRoutingPhoneEndpoint extends CallRoutingEndpoint
 {
     public const TYPE = 'PHONE';

--- a/Infobip/Model/CallRoutingSipCriteria.php
+++ b/Infobip/Model/CallRoutingSipCriteria.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRoutingSipCriteria extends CallRoutingCriteria
 {
     public const TYPE = 'SIP';

--- a/Infobip/Model/CallRoutingUrlDestinationResponse.php
+++ b/Infobip/Model/CallRoutingUrlDestinationResponse.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "ENDPOINT" => "\Infobip\Model\CallRoutingEndpointDestinationResponse",

--- a/Infobip/Model/CallRoutingViberEndpoint.php
+++ b/Infobip/Model/CallRoutingViberEndpoint.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRoutingViberEndpoint extends CallRoutingEndpoint
 {
     public const TYPE = 'VIBER';

--- a/Infobip/Model/CallRoutingWebRTCCriteria.php
+++ b/Infobip/Model/CallRoutingWebRTCCriteria.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallRoutingWebRTCCriteria extends CallRoutingCriteria
 {
     public const TYPE = 'WEBRTC';

--- a/Infobip/Model/CallRoutingWebRtcEndpoint.php
+++ b/Infobip/Model/CallRoutingWebRtcEndpoint.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
-
 class CallRoutingWebRtcEndpoint extends CallRoutingEndpoint
 {
     public const TYPE = 'WEBRTC';
@@ -25,8 +23,7 @@ class CallRoutingWebRtcEndpoint extends CallRoutingEndpoint
     /**
      */
     public function __construct(
-        #[Assert\NotBlank]
-        protected string $identity,
+        protected ?string $identity = null,
     ) {
         $modelDiscriminatorValue = self::TYPE;
 
@@ -36,12 +33,12 @@ class CallRoutingWebRtcEndpoint extends CallRoutingEndpoint
     }
 
 
-    public function getIdentity(): string
+    public function getIdentity(): string|null
     {
         return $this->identity;
     }
 
-    public function setIdentity(string $identity): self
+    public function setIdentity(?string $identity): self
     {
         $this->identity = $identity;
         return $this;

--- a/Infobip/Model/CallbackResponse.php
+++ b/Infobip/Model/CallbackResponse.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "command", mapping: [
     "audio" => "\Infobip\Model\CallsAudioCallbackResponse",

--- a/Infobip/Model/CallsActionResponse.php
+++ b/Infobip/Model/CallsActionResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsActionResponse
 {
     /**

--- a/Infobip/Model/CallsAdvancedMessage.php
+++ b/Infobip/Model/CallsAdvancedMessage.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsAdvancedMessage
 {

--- a/Infobip/Model/CallsAnnouncementCallee.php
+++ b/Infobip/Model/CallsAnnouncementCallee.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsAnnouncementCallee
 {
     /**

--- a/Infobip/Model/CallsAnnouncementCaller.php
+++ b/Infobip/Model/CallsAnnouncementCaller.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsAnnouncementCaller
 {
     /**

--- a/Infobip/Model/CallsAudioCallbackResponse.php
+++ b/Infobip/Model/CallsAudioCallbackResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsAudioCallbackResponse extends CallbackResponse
 {
     public const COMMAND = 'audio';

--- a/Infobip/Model/CallsAudioMediaProperties.php
+++ b/Infobip/Model/CallsAudioMediaProperties.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsAudioMediaProperties
 {
     /**

--- a/Infobip/Model/CallsBulkRequest.php
+++ b/Infobip/Model/CallsBulkRequest.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsBulkRequest
 {

--- a/Infobip/Model/CallsConferenceBroadcastWebrtcTextRequest.php
+++ b/Infobip/Model/CallsConferenceBroadcastWebrtcTextRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsConferenceBroadcastWebrtcTextRequest
 {
     /**

--- a/Infobip/Model/CallsConferenceComposition.php
+++ b/Infobip/Model/CallsConferenceComposition.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsConferenceComposition
 {
     /**

--- a/Infobip/Model/CallsConferenceLog.php
+++ b/Infobip/Model/CallsConferenceLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsConferenceLog
 {

--- a/Infobip/Model/CallsConferenceRecording.php
+++ b/Infobip/Model/CallsConferenceRecording.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsConferenceRecording
 {

--- a/Infobip/Model/CallsConferenceRecordingLog.php
+++ b/Infobip/Model/CallsConferenceRecordingLog.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsConferenceRecordingLog
 {
     /**

--- a/Infobip/Model/CallsCountryList.php
+++ b/Infobip/Model/CallsCountryList.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsCountryList
 {
     /**

--- a/Infobip/Model/CallsCreateSipTrunkResponse.php
+++ b/Infobip/Model/CallsCreateSipTrunkResponse.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PROVIDER" => "\Infobip\Model\CallsCreateProviderSipTrunkResponse",

--- a/Infobip/Model/CallsDialogBroadcastWebrtcTextRequest.php
+++ b/Infobip/Model/CallsDialogBroadcastWebrtcTextRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsDialogBroadcastWebrtcTextRequest
 {
     /**

--- a/Infobip/Model/CallsDialogLogResponse.php
+++ b/Infobip/Model/CallsDialogLogResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsDialogLogResponse
 {

--- a/Infobip/Model/CallsDialogRecordingComposition.php
+++ b/Infobip/Model/CallsDialogRecordingComposition.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsDialogRecordingComposition
 {
     /**

--- a/Infobip/Model/CallsDialogRecordingLog.php
+++ b/Infobip/Model/CallsDialogRecordingLog.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsDialogRecordingLog
 {
     /**

--- a/Infobip/Model/CallsDialogRecordingResponse.php
+++ b/Infobip/Model/CallsDialogRecordingResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsDialogRecordingResponse
 {

--- a/Infobip/Model/CallsDialogResponse.php
+++ b/Infobip/Model/CallsDialogResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsDialogResponse
 {

--- a/Infobip/Model/CallsDtmfTermination.php
+++ b/Infobip/Model/CallsDtmfTermination.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsDtmfTermination extends CallsTermination
 {
     public const TYPE = 'DTMF';

--- a/Infobip/Model/CallsErrorCode.php
+++ b/Infobip/Model/CallsErrorCode.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 final class CallsErrorCode implements EnumInterface
 {
     public const NORMAL_HANGUP = 'NORMAL_HANGUP';
+    public const MACHINE_DETECTED = 'MACHINE_DETECTED';
     public const NO_ANSWER = 'NO_ANSWER';
     public const BUSY = 'BUSY';
     public const CANCELLED = 'CANCELLED';
@@ -35,6 +36,7 @@ final class CallsErrorCode implements EnumInterface
 
     public const ALLOWED_VALUES = [
         'NORMAL_HANGUP',
+        'MACHINE_DETECTED',
         'NO_ANSWER',
         'BUSY',
         'CANCELLED',
@@ -68,6 +70,11 @@ final class CallsErrorCode implements EnumInterface
     public static function NORMAL_HANGUP(): CallsErrorCode
     {
         return new self('NORMAL_HANGUP');
+    }
+
+    public static function MACHINE_DETECTED(): CallsErrorCode
+    {
+        return new self('MACHINE_DETECTED');
     }
 
     public static function NO_ANSWER(): CallsErrorCode

--- a/Infobip/Model/CallsErrorCodeInfo.php
+++ b/Infobip/Model/CallsErrorCodeInfo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsErrorCodeInfo
 {
     /**

--- a/Infobip/Model/CallsFile.php
+++ b/Infobip/Model/CallsFile.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsFile
 {

--- a/Infobip/Model/CallsGetVoicesResponse.php
+++ b/Infobip/Model/CallsGetVoicesResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsGetVoicesResponse
 {
     /**

--- a/Infobip/Model/CallsHangupRequest.php
+++ b/Infobip/Model/CallsHangupRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsHangupRequest
 {
     /**

--- a/Infobip/Model/CallsIvrData.php
+++ b/Infobip/Model/CallsIvrData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsIvrData
 {
     /**

--- a/Infobip/Model/CallsIvrMessage.php
+++ b/Infobip/Model/CallsIvrMessage.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsIvrMessage
 {

--- a/Infobip/Model/CallsLogsReport.php
+++ b/Infobip/Model/CallsLogsReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsLogsReport
 {

--- a/Infobip/Model/CallsLogsResponse.php
+++ b/Infobip/Model/CallsLogsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsLogsResponse
 {
     /**

--- a/Infobip/Model/CallsMachineDetectionProperties.php
+++ b/Infobip/Model/CallsMachineDetectionProperties.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsMachineDetectionProperties
 {
     /**

--- a/Infobip/Model/CallsMediaStreamConfigResponse.php
+++ b/Infobip/Model/CallsMediaStreamConfigResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsMediaStreamConfigResponse
 {
     /**

--- a/Infobip/Model/CallsNumbers.php
+++ b/Infobip/Model/CallsNumbers.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsNumbers
 {
     /**

--- a/Infobip/Model/CallsParticipant.php
+++ b/Infobip/Model/CallsParticipant.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsParticipant
 {

--- a/Infobip/Model/CallsParticipantSession.php
+++ b/Infobip/Model/CallsParticipantSession.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsParticipantSession
 {

--- a/Infobip/Model/CallsPreAnswerRequest.php
+++ b/Infobip/Model/CallsPreAnswerRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsPreAnswerRequest
 {
     /**

--- a/Infobip/Model/CallsPrice.php
+++ b/Infobip/Model/CallsPrice.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsPrice
 {
     /**

--- a/Infobip/Model/CallsPublicCountry.php
+++ b/Infobip/Model/CallsPublicCountry.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsPublicCountry
 {
     /**

--- a/Infobip/Model/CallsPublicRegion.php
+++ b/Infobip/Model/CallsPublicRegion.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsPublicRegion
 {
     /**

--- a/Infobip/Model/CallsRecordOptions.php
+++ b/Infobip/Model/CallsRecordOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsRecordOptions
 {
     /**

--- a/Infobip/Model/CallsRecordedAudioFilesResponse.php
+++ b/Infobip/Model/CallsRecordedAudioFilesResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsRecordedAudioFilesResponse
 {
     /**

--- a/Infobip/Model/CallsRecording.php
+++ b/Infobip/Model/CallsRecording.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsRecording
 {
     /**

--- a/Infobip/Model/CallsRecordingFile.php
+++ b/Infobip/Model/CallsRecordingFile.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsRecordingFile
 {

--- a/Infobip/Model/CallsRegionList.php
+++ b/Infobip/Model/CallsRegionList.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsRegionList
 {
     /**

--- a/Infobip/Model/CallsReportResponse.php
+++ b/Infobip/Model/CallsReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsReportResponse
 {
     /**

--- a/Infobip/Model/CallsRescheduleRequest.php
+++ b/Infobip/Model/CallsRescheduleRequest.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsRescheduleRequest
 {

--- a/Infobip/Model/CallsRetryOptions.php
+++ b/Infobip/Model/CallsRetryOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsRetryOptions
 {
     /**

--- a/Infobip/Model/CallsSbcHosts.php
+++ b/Infobip/Model/CallsSbcHosts.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSbcHosts
 {
     /**

--- a/Infobip/Model/CallsSchedulingOptions.php
+++ b/Infobip/Model/CallsSchedulingOptions.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CallsSchedulingOptions
 {

--- a/Infobip/Model/CallsSearchResponse.php
+++ b/Infobip/Model/CallsSearchResponse.php
@@ -84,12 +84,18 @@ class CallsSearchResponse
         return $this;
     }
 
-    public function getScript(): object|null
+    /**
+     * @return \Infobip\Model\CallsScriptOneOf[]|null
+     */
+    public function getScript(): ?array
     {
         return $this->script;
     }
 
-    public function setScript(?object $script): self
+    /**
+     * @param \Infobip\Model\CallsScriptOneOf[]|null $script Array of IVR actions defining scenario. NOTE: Answering Machine Detection, Call Recording and Speech Recognition (used for Capture action) are add-on features. To enable these add-ons, please contact our [sales](https://www.infobip.com/contact) organisation.
+     */
+    public function setScript(?array $script): self
     {
         $this->script = $script;
         return $this;

--- a/Infobip/Model/CallsSendingSpeed.php
+++ b/Infobip/Model/CallsSendingSpeed.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSendingSpeed
 {
     /**

--- a/Infobip/Model/CallsSingleMessageStatus.php
+++ b/Infobip/Model/CallsSingleMessageStatus.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSingleMessageStatus
 {
     /**

--- a/Infobip/Model/CallsSipOptions.php
+++ b/Infobip/Model/CallsSipOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSipOptions
 {
     /**

--- a/Infobip/Model/CallsSipTrunkActionStatusResponse.php
+++ b/Infobip/Model/CallsSipTrunkActionStatusResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSipTrunkActionStatusResponse
 {
     /**

--- a/Infobip/Model/CallsSipTrunkRegistrationCredentials.php
+++ b/Infobip/Model/CallsSipTrunkRegistrationCredentials.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSipTrunkRegistrationCredentials
 {
     /**

--- a/Infobip/Model/CallsSipTrunkRequest.php
+++ b/Infobip/Model/CallsSipTrunkRequest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PROVIDER" => "\Infobip\Model\CallsProviderSipTrunkRequest",

--- a/Infobip/Model/CallsSipTrunkResponse.php
+++ b/Infobip/Model/CallsSipTrunkResponse.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PROVIDER" => "\Infobip\Model\CallsProviderSipTrunkResponse",

--- a/Infobip/Model/CallsSipTrunkStatusResponse.php
+++ b/Infobip/Model/CallsSipTrunkStatusResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsSipTrunkStatusResponse
 {
     /**

--- a/Infobip/Model/CallsSipTrunkUpdateRequest.php
+++ b/Infobip/Model/CallsSipTrunkUpdateRequest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "PROVIDER" => "\Infobip\Model\CallsProviderSipTrunkUpdateRequest",

--- a/Infobip/Model/CallsStopPlayRequest.php
+++ b/Infobip/Model/CallsStopPlayRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsStopPlayRequest
 {
     /**

--- a/Infobip/Model/CallsUpdateRequest.php
+++ b/Infobip/Model/CallsUpdateRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsUpdateRequest
 {
     /**

--- a/Infobip/Model/CallsUpdateScenarioResponse.php
+++ b/Infobip/Model/CallsUpdateScenarioResponse.php
@@ -84,12 +84,18 @@ class CallsUpdateScenarioResponse
         return $this;
     }
 
-    public function getScript(): object|null
+    /**
+     * @return \Infobip\Model\CallsScriptOneOf[]|null
+     */
+    public function getScript(): ?array
     {
         return $this->script;
     }
 
-    public function setScript(?object $script): self
+    /**
+     * @param \Infobip\Model\CallsScriptOneOf[]|null $script Array of IVR actions defining scenario. NOTE: Answering Machine Detection, Call Recording and Speech Recognition (used for Capture action) are add-on features. To enable these add-ons, please contact our [sales](https://www.infobip.com/contact) organisation.
+     */
+    public function setScript(?array $script): self
     {
         $this->script = $script;
         return $this;

--- a/Infobip/Model/CallsVideoMediaProperties.php
+++ b/Infobip/Model/CallsVideoMediaProperties.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVideoMediaProperties
 {
     /**

--- a/Infobip/Model/CallsVoice.php
+++ b/Infobip/Model/CallsVoice.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVoice
 {
     /**

--- a/Infobip/Model/CallsVoiceError.php
+++ b/Infobip/Model/CallsVoiceError.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVoiceError
 {
     /**

--- a/Infobip/Model/CallsVoiceOptions.php
+++ b/Infobip/Model/CallsVoiceOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVoiceOptions
 {
     /**

--- a/Infobip/Model/CallsVoicePreferences.php
+++ b/Infobip/Model/CallsVoicePreferences.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVoicePreferences
 {
     /**

--- a/Infobip/Model/CallsVoiceResponse.php
+++ b/Infobip/Model/CallsVoiceResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class CallsVoiceResponse
 {
     /**

--- a/Infobip/Model/ClientRecording.php
+++ b/Infobip/Model/ClientRecording.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ClientRecording
 {
     /**

--- a/Infobip/Model/EmailBulkRescheduleRequest.php
+++ b/Infobip/Model/EmailBulkRescheduleRequest.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class EmailBulkRescheduleRequest
 {

--- a/Infobip/Model/EmailBulkScheduleResponse.php
+++ b/Infobip/Model/EmailBulkScheduleResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailBulkScheduleResponse
 {
     /**

--- a/Infobip/Model/EmailBulkStatusInfo.php
+++ b/Infobip/Model/EmailBulkStatusInfo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailBulkStatusInfo
 {
     /**

--- a/Infobip/Model/EmailBulkStatusResponse.php
+++ b/Infobip/Model/EmailBulkStatusResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailBulkStatusResponse
 {
     /**

--- a/Infobip/Model/EmailBulkUpdateStatusResponse.php
+++ b/Infobip/Model/EmailBulkUpdateStatusResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailBulkUpdateStatusResponse
 {
     /**

--- a/Infobip/Model/EmailDnsRecordResponse.php
+++ b/Infobip/Model/EmailDnsRecordResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailDnsRecordResponse
 {
     /**

--- a/Infobip/Model/EmailDomainResponse.php
+++ b/Infobip/Model/EmailDomainResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class EmailDomainResponse
 {

--- a/Infobip/Model/EmailLog.php
+++ b/Infobip/Model/EmailLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class EmailLog
 {

--- a/Infobip/Model/EmailLogsResponse.php
+++ b/Infobip/Model/EmailLogsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailLogsResponse
 {
     /**

--- a/Infobip/Model/EmailPaging.php
+++ b/Infobip/Model/EmailPaging.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailPaging
 {
     /**

--- a/Infobip/Model/EmailReport.php
+++ b/Infobip/Model/EmailReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class EmailReport
 {

--- a/Infobip/Model/EmailReportsResult.php
+++ b/Infobip/Model/EmailReportsResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailReportsResult
 {
     /**

--- a/Infobip/Model/EmailSendResponse.php
+++ b/Infobip/Model/EmailSendResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailSendResponse
 {
     /**

--- a/Infobip/Model/EmailTrackingEventRequest.php
+++ b/Infobip/Model/EmailTrackingEventRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailTrackingEventRequest
 {
     /**

--- a/Infobip/Model/EmailTrackingResponse.php
+++ b/Infobip/Model/EmailTrackingResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailTrackingResponse
 {
     /**

--- a/Infobip/Model/EmailValidationResponse.php
+++ b/Infobip/Model/EmailValidationResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailValidationResponse
 {
     /**

--- a/Infobip/Model/EmailWebhookDLRReportResponse.php
+++ b/Infobip/Model/EmailWebhookDLRReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailWebhookDLRReportResponse
 {
     /**

--- a/Infobip/Model/EmailWebhookDeliveryReport.php
+++ b/Infobip/Model/EmailWebhookDeliveryReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class EmailWebhookDeliveryReport
 {

--- a/Infobip/Model/EmailWebhookGeoLocation.php
+++ b/Infobip/Model/EmailWebhookGeoLocation.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailWebhookGeoLocation
 {
     /**

--- a/Infobip/Model/EmailWebhookRecipientInfo.php
+++ b/Infobip/Model/EmailWebhookRecipientInfo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class EmailWebhookRecipientInfo
 {
     /**

--- a/Infobip/Model/FlowAddFlowParticipantResult.php
+++ b/Infobip/Model/FlowAddFlowParticipantResult.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowAddFlowParticipantResult
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\Valid]
+        #[Assert\NotBlank]
+        protected \Infobip\Model\FlowPersonUniqueField $identifyBy,
+        #[Assert\NotBlank]
+        protected string $status,
+        protected ?string $errorReason = null,
+    ) {
+
+    }
+
+
+    public function getIdentifyBy(): \Infobip\Model\FlowPersonUniqueField
+    {
+        return $this->identifyBy;
+    }
+
+    public function setIdentifyBy(\Infobip\Model\FlowPersonUniqueField $identifyBy): self
+    {
+        $this->identifyBy = $identifyBy;
+        return $this;
+    }
+
+    public function getStatus(): mixed
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getErrorReason(): mixed
+    {
+        return $this->errorReason;
+    }
+
+    public function setErrorReason($errorReason): self
+    {
+        $this->errorReason = $errorReason;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowAddFlowParticipantStatus.php
+++ b/Infobip/Model/FlowAddFlowParticipantStatus.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowAddFlowParticipantStatus implements EnumInterface
+{
+    public const PENDING = 'PENDING';
+    public const REJECTED = 'REJECTED';
+    public const ACCEPTED = 'ACCEPTED';
+
+    public const ALLOWED_VALUES = [
+        'PENDING',
+        'REJECTED',
+        'ACCEPTED',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function PENDING(): FlowAddFlowParticipantStatus
+    {
+        return new self('PENDING');
+    }
+
+    public static function REJECTED(): FlowAddFlowParticipantStatus
+    {
+        return new self('REJECTED');
+    }
+
+    public static function ACCEPTED(): FlowAddFlowParticipantStatus
+    {
+        return new self('ACCEPTED');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FlowAddFlowParticipantsRequest.php
+++ b/Infobip/Model/FlowAddFlowParticipantsRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowAddFlowParticipantsRequest
+{
+    /**
+     * @param \Infobip\Model\FlowParticipant[] $participants
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected array $participants,
+        #[Assert\Length(max: 1000)]
+        protected ?string $notifyUrl = null,
+        #[Assert\Length(max: 2000)]
+        protected ?string $callbackData = null,
+    ) {
+
+    }
+
+
+    /**
+     * @return \Infobip\Model\FlowParticipant[]
+     */
+    public function getParticipants(): array
+    {
+        return $this->participants;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowParticipant[] $participants Array of participants to add.
+     */
+    public function setParticipants(array $participants): self
+    {
+        $this->participants = $participants;
+        return $this;
+    }
+
+    public function getNotifyUrl(): string|null
+    {
+        return $this->notifyUrl;
+    }
+
+    public function setNotifyUrl(?string $notifyUrl): self
+    {
+        $this->notifyUrl = $notifyUrl;
+        return $this;
+    }
+
+    public function getCallbackData(): string|null
+    {
+        return $this->callbackData;
+    }
+
+    public function setCallbackData(?string $callbackData): self
+    {
+        $this->callbackData = $callbackData;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowAddFlowParticipantsResponse.php
+++ b/Infobip/Model/FlowAddFlowParticipantsResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowAddFlowParticipantsResponse
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $operationId,
+    ) {
+
+    }
+
+
+    public function getOperationId(): string
+    {
+        return $this->operationId;
+    }
+
+    public function setOperationId(string $operationId): self
+    {
+        $this->operationId = $operationId;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowCommonOttContact.php
+++ b/Infobip/Model/FlowCommonOttContact.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowCommonOttContact
+{
+    /**
+     * @param array<string,object> $systemData
+     */
+    public function __construct(
+        protected ?string $applicationId = null,
+        protected ?string $userId = null,
+        protected ?array $systemData = null,
+    ) {
+
+    }
+
+
+    public function getApplicationId(): string|null
+    {
+        return $this->applicationId;
+    }
+
+    public function setApplicationId(?string $applicationId): self
+    {
+        $this->applicationId = $applicationId;
+        return $this;
+    }
+
+    public function getUserId(): string|null
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(?string $userId): self
+    {
+        $this->userId = $userId;
+        return $this;
+    }
+
+    /**
+     * @return array<string,object>|null
+     */
+    public function getSystemData()
+    {
+        return $this->systemData;
+    }
+
+    /**
+     * @param array<string,object>|null $systemData System data collected from the user's profile.
+     */
+    public function setSystemData(?array $systemData): self
+    {
+        $this->systemData = $systemData;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowCommonPushContact.php
+++ b/Infobip/Model/FlowCommonPushContact.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowCommonPushContact
+{
+    /**
+     * @param array<string,object> $additionalData
+     * @param array<string,object> $systemData
+     */
+    public function __construct(
+        protected ?string $applicationId = null,
+        protected ?string $registrationId = null,
+        protected ?array $additionalData = null,
+        protected ?array $systemData = null,
+    ) {
+
+    }
+
+
+    public function getApplicationId(): string|null
+    {
+        return $this->applicationId;
+    }
+
+    public function setApplicationId(?string $applicationId): self
+    {
+        $this->applicationId = $applicationId;
+        return $this;
+    }
+
+    public function getRegistrationId(): string|null
+    {
+        return $this->registrationId;
+    }
+
+    public function setRegistrationId(?string $registrationId): self
+    {
+        $this->registrationId = $registrationId;
+        return $this;
+    }
+
+    /**
+     * @return array<string,object>|null
+     */
+    public function getAdditionalData()
+    {
+        return $this->additionalData;
+    }
+
+    /**
+     * @param array<string,object>|null $additionalData Unique user ID for a person.
+     */
+    public function setAdditionalData(?array $additionalData): self
+    {
+        $this->additionalData = $additionalData;
+        return $this;
+    }
+
+    /**
+     * @return array<string,object>|null
+     */
+    public function getSystemData()
+    {
+        return $this->systemData;
+    }
+
+    /**
+     * @param array<string,object>|null $systemData System data collected from the user's profile.
+     */
+    public function setSystemData(?array $systemData): self
+    {
+        $this->systemData = $systemData;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowEmailContact.php
+++ b/Infobip/Model/FlowEmailContact.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowEmailContact
+{
+    /**
+     */
+    public function __construct(
+        protected ?string $address = null,
+    ) {
+
+    }
+
+
+    public function getAddress(): string|null
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): self
+    {
+        $this->address = $address;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowErrorStatusReason.php
+++ b/Infobip/Model/FlowErrorStatusReason.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowErrorStatusReason implements EnumInterface
+{
+    public const INVALID_CONTACT = 'REJECTED_INVALID_CONTACT';
+    public const ATTRIBUTE_MISSED = 'REJECTED_ATTRIBUTE_MISSED';
+    public const PERSON_IN_FLOW = 'REJECTED_PERSON_IN_FLOW';
+    public const PERSON_NOT_ALLOWED_TO_REENTER = 'REJECTED_PERSON_NOT_ALLOWED_TO_REENTER';
+    public const FLOW_ERROR_UNKNOWN = 'REJECTED_FLOW_ERROR_UNKNOWN';
+    public const NOT_ENOUGH_CREDITS = 'REJECTED_NOT_ENOUGH_CREDITS';
+    public const CDP_ERROR_UNKNOWN = 'REJECTED_CDP_ERROR_UNKNOWN';
+
+    public const ALLOWED_VALUES = [
+        'REJECTED_INVALID_CONTACT',
+        'REJECTED_ATTRIBUTE_MISSED',
+        'REJECTED_PERSON_IN_FLOW',
+        'REJECTED_PERSON_NOT_ALLOWED_TO_REENTER',
+        'REJECTED_FLOW_ERROR_UNKNOWN',
+        'REJECTED_NOT_ENOUGH_CREDITS',
+        'REJECTED_CDP_ERROR_UNKNOWN',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function INVALID_CONTACT(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_INVALID_CONTACT');
+    }
+
+    public static function ATTRIBUTE_MISSED(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_ATTRIBUTE_MISSED');
+    }
+
+    public static function PERSON_IN_FLOW(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_PERSON_IN_FLOW');
+    }
+
+    public static function PERSON_NOT_ALLOWED_TO_REENTER(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_PERSON_NOT_ALLOWED_TO_REENTER');
+    }
+
+    public static function FLOW_ERROR_UNKNOWN(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_FLOW_ERROR_UNKNOWN');
+    }
+
+    public static function NOT_ENOUGH_CREDITS(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_NOT_ENOUGH_CREDITS');
+    }
+
+    public static function CDP_ERROR_UNKNOWN(): FlowErrorStatusReason
+    {
+        return new self('REJECTED_CDP_ERROR_UNKNOWN');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FlowExceptionResponse.php
+++ b/Infobip/Model/FlowExceptionResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowExceptionResponse
+{
+    /**
+     */
+    public function __construct(
+        protected ?int $errorCode = null,
+        protected ?string $errorMessage = null,
+    ) {
+
+    }
+
+
+    public function getErrorCode(): int|null
+    {
+        return $this->errorCode;
+    }
+
+    public function setErrorCode(?int $errorCode): self
+    {
+        $this->errorCode = $errorCode;
+        return $this;
+    }
+
+    public function getErrorMessage(): string|null
+    {
+        return $this->errorMessage;
+    }
+
+    public function setErrorMessage(?string $errorMessage): self
+    {
+        $this->errorMessage = $errorMessage;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowGender.php
+++ b/Infobip/Model/FlowGender.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowGender implements EnumInterface
+{
+    public const MALE = 'MALE';
+    public const FEMALE = 'FEMALE';
+
+    public const ALLOWED_VALUES = [
+        'MALE',
+        'FEMALE',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function MALE(): FlowGender
+    {
+        return new self('MALE');
+    }
+
+    public static function FEMALE(): FlowGender
+    {
+        return new self('FEMALE');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FlowIntegrations.php
+++ b/Infobip/Model/FlowIntegrations.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowIntegrations
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FlowSalesforce $salesforce = null,
+    ) {
+
+    }
+
+
+    public function getSalesforce(): \Infobip\Model\FlowSalesforce|null
+    {
+        return $this->salesforce;
+    }
+
+    public function setSalesforce(?\Infobip\Model\FlowSalesforce $salesforce): self
+    {
+        $this->salesforce = $salesforce;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowOrigin.php
+++ b/Infobip/Model/FlowOrigin.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowOrigin implements EnumInterface
+{
+    public const API = 'API';
+    public const PORTAL = 'PORTAL';
+    public const WEB_SDK = 'WEB_SDK';
+    public const INTEGRATION = 'INTEGRATION';
+    public const PUSH = 'PUSH';
+    public const FACEBOOK = 'FACEBOOK';
+    public const LINE = 'LINE';
+    public const TELEGRAM = 'TELEGRAM';
+    public const SALESFORCE = 'SALESFORCE';
+    public const DYNAMICS = 'DYNAMICS';
+    public const ZAPIER = 'ZAPIER';
+    public const FORMS = 'FORMS';
+    public const COMPUTED = 'COMPUTED';
+    public const ANSWERS = 'ANSWERS';
+    public const CONVERSATIONS = 'CONVERSATIONS';
+
+    public const ALLOWED_VALUES = [
+        'API',
+        'PORTAL',
+        'WEB_SDK',
+        'INTEGRATION',
+        'PUSH',
+        'FACEBOOK',
+        'LINE',
+        'TELEGRAM',
+        'SALESFORCE',
+        'DYNAMICS',
+        'ZAPIER',
+        'FORMS',
+        'COMPUTED',
+        'ANSWERS',
+        'CONVERSATIONS',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function API(): FlowOrigin
+    {
+        return new self('API');
+    }
+
+    public static function PORTAL(): FlowOrigin
+    {
+        return new self('PORTAL');
+    }
+
+    public static function WEB_SDK(): FlowOrigin
+    {
+        return new self('WEB_SDK');
+    }
+
+    public static function INTEGRATION(): FlowOrigin
+    {
+        return new self('INTEGRATION');
+    }
+
+    public static function PUSH(): FlowOrigin
+    {
+        return new self('PUSH');
+    }
+
+    public static function FACEBOOK(): FlowOrigin
+    {
+        return new self('FACEBOOK');
+    }
+
+    public static function LINE(): FlowOrigin
+    {
+        return new self('LINE');
+    }
+
+    public static function TELEGRAM(): FlowOrigin
+    {
+        return new self('TELEGRAM');
+    }
+
+    public static function SALESFORCE(): FlowOrigin
+    {
+        return new self('SALESFORCE');
+    }
+
+    public static function DYNAMICS(): FlowOrigin
+    {
+        return new self('DYNAMICS');
+    }
+
+    public static function ZAPIER(): FlowOrigin
+    {
+        return new self('ZAPIER');
+    }
+
+    public static function FORMS(): FlowOrigin
+    {
+        return new self('FORMS');
+    }
+
+    public static function COMPUTED(): FlowOrigin
+    {
+        return new self('COMPUTED');
+    }
+
+    public static function ANSWERS(): FlowOrigin
+    {
+        return new self('ANSWERS');
+    }
+
+    public static function CONVERSATIONS(): FlowOrigin
+    {
+        return new self('CONVERSATIONS');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FlowParticipant.php
+++ b/Infobip/Model/FlowParticipant.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowParticipant
+{
+    /**
+     * @param array<string,mixed> $variables
+     */
+    public function __construct(
+        #[Assert\Valid]
+        #[Assert\NotBlank]
+        protected \Infobip\Model\FlowPersonUniqueField $identifyBy,
+        protected ?array $variables = null,
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FlowPerson $person = null,
+    ) {
+
+    }
+
+
+    public function getIdentifyBy(): \Infobip\Model\FlowPersonUniqueField
+    {
+        return $this->identifyBy;
+    }
+
+    public function setIdentifyBy(\Infobip\Model\FlowPersonUniqueField $identifyBy): self
+    {
+        $this->identifyBy = $identifyBy;
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getVariables()
+    {
+        return $this->variables;
+    }
+
+    /**
+     * @param array<string,mixed>|null $variables Flow variables to assign to the participant when it is added to the flow.
+     */
+    public function setVariables(?array $variables): self
+    {
+        $this->variables = $variables;
+        return $this;
+    }
+
+    public function getPerson(): \Infobip\Model\FlowPerson|null
+    {
+        return $this->person;
+    }
+
+    public function setPerson(?\Infobip\Model\FlowPerson $person): self
+    {
+        $this->person = $person;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowParticipantsReportResponse.php
+++ b/Infobip/Model/FlowParticipantsReportResponse.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowParticipantsReportResponse
+{
+    /**
+     * @param \Infobip\Model\FlowAddFlowParticipantResult[] $participants
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $operationId,
+        #[Assert\NotBlank]
+        protected int $campaignId,
+        #[Assert\NotBlank]
+        protected array $participants,
+        protected ?string $callbackData = null,
+    ) {
+
+    }
+
+
+    public function getOperationId(): string
+    {
+        return $this->operationId;
+    }
+
+    public function setOperationId(string $operationId): self
+    {
+        $this->operationId = $operationId;
+        return $this;
+    }
+
+    public function getCampaignId(): int
+    {
+        return $this->campaignId;
+    }
+
+    public function setCampaignId(int $campaignId): self
+    {
+        $this->campaignId = $campaignId;
+        return $this;
+    }
+
+    public function getCallbackData(): string|null
+    {
+        return $this->callbackData;
+    }
+
+    public function setCallbackData(?string $callbackData): self
+    {
+        $this->callbackData = $callbackData;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowAddFlowParticipantResult[]
+     */
+    public function getParticipants(): array
+    {
+        return $this->participants;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowAddFlowParticipantResult[] $participants Array with information about each participant submitted for the operation.
+     */
+    public function setParticipants(array $participants): self
+    {
+        $this->participants = $participants;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowPerson.php
+++ b/Infobip/Model/FlowPerson.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowPerson
+{
+    /**
+     * @param string[] $tags
+     * @param array<string,mixed> $customAttributes
+     * @param array<string,mixed> $computedAttributes
+     */
+    public function __construct(
+        protected ?string $createdAt = null,
+        protected ?string $modifiedAt = null,
+        protected ?int $id = null,
+        protected ?string $externalId = null,
+        protected ?string $firstName = null,
+        protected ?string $lastName = null,
+        protected ?string $type = null,
+        protected ?string $address = null,
+        protected ?string $city = null,
+        protected ?string $country = null,
+        protected ?string $gender = null,
+        protected ?string $birthDate = null,
+        protected ?string $middleName = null,
+        protected ?string $preferredLanguage = null,
+        protected ?string $profilePicture = null,
+        protected ?string $origin = null,
+        protected ?string $modifiedFrom = null,
+        protected ?array $tags = null,
+        protected ?array $customAttributes = null,
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FlowPersonContacts $contactInformation = null,
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FlowIntegrations $integrations = null,
+        protected ?array $computedAttributes = null,
+    ) {
+
+    }
+
+
+    public function getCreatedAt(): string|null
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getModifiedAt(): string|null
+    {
+        return $this->modifiedAt;
+    }
+
+    public function setModifiedAt(?string $modifiedAt): self
+    {
+        $this->modifiedAt = $modifiedAt;
+        return $this;
+    }
+
+    public function getId(): int|null
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getExternalId(): string|null
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(?string $externalId): self
+    {
+        $this->externalId = $externalId;
+        return $this;
+    }
+
+    public function getFirstName(): string|null
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getLastName(): string|null
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+
+    public function getType(): mixed
+    {
+        return $this->type;
+    }
+
+    public function setType($type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getAddress(): string|null
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): self
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    public function getCity(): string|null
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+    public function getCountry(): string|null
+    {
+        return $this->country;
+    }
+
+    public function setCountry(?string $country): self
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    public function getGender(): mixed
+    {
+        return $this->gender;
+    }
+
+    public function setGender($gender): self
+    {
+        $this->gender = $gender;
+        return $this;
+    }
+
+    public function getBirthDate(): string|null
+    {
+        return $this->birthDate;
+    }
+
+    public function setBirthDate(?string $birthDate): self
+    {
+        $this->birthDate = $birthDate;
+        return $this;
+    }
+
+    public function getMiddleName(): string|null
+    {
+        return $this->middleName;
+    }
+
+    public function setMiddleName(?string $middleName): self
+    {
+        $this->middleName = $middleName;
+        return $this;
+    }
+
+    public function getPreferredLanguage(): string|null
+    {
+        return $this->preferredLanguage;
+    }
+
+    public function setPreferredLanguage(?string $preferredLanguage): self
+    {
+        $this->preferredLanguage = $preferredLanguage;
+        return $this;
+    }
+
+    public function getProfilePicture(): string|null
+    {
+        return $this->profilePicture;
+    }
+
+    public function setProfilePicture(?string $profilePicture): self
+    {
+        $this->profilePicture = $profilePicture;
+        return $this;
+    }
+
+    public function getOrigin(): mixed
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin($origin): self
+    {
+        $this->origin = $origin;
+        return $this;
+    }
+
+    public function getModifiedFrom(): mixed
+    {
+        return $this->modifiedFrom;
+    }
+
+    public function setModifiedFrom($modifiedFrom): self
+    {
+        $this->modifiedFrom = $modifiedFrom;
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getTags(): ?array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param string[]|null $tags List of tags that this person has.
+     */
+    public function setTags(?array $tags): self
+    {
+        $this->tags = $tags;
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getCustomAttributes()
+    {
+        return $this->customAttributes;
+    }
+
+    /**
+     * @param array<string,mixed>|null $customAttributes List of custom attributes for the person, 4096 characters max per value.
+     */
+    public function setCustomAttributes(?array $customAttributes): self
+    {
+        $this->customAttributes = $customAttributes;
+        return $this;
+    }
+
+    public function getContactInformation(): \Infobip\Model\FlowPersonContacts|null
+    {
+        return $this->contactInformation;
+    }
+
+    public function setContactInformation(?\Infobip\Model\FlowPersonContacts $contactInformation): self
+    {
+        $this->contactInformation = $contactInformation;
+        return $this;
+    }
+
+    public function getIntegrations(): \Infobip\Model\FlowIntegrations|null
+    {
+        return $this->integrations;
+    }
+
+    public function setIntegrations(?\Infobip\Model\FlowIntegrations $integrations): self
+    {
+        $this->integrations = $integrations;
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getComputedAttributes()
+    {
+        return $this->computedAttributes;
+    }
+
+    /**
+     * @param array<string,mixed>|null $computedAttributes Person's computed attributes grouped by type.
+     */
+    public function setComputedAttributes(?array $computedAttributes): self
+    {
+        $this->computedAttributes = $computedAttributes;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowPersonContacts.php
+++ b/Infobip/Model/FlowPersonContacts.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowPersonContacts
+{
+    /**
+     * @param \Infobip\Model\FlowPhoneContact[] $phone
+     * @param \Infobip\Model\FlowEmailContact[] $email
+     * @param \Infobip\Model\FlowPushContact[] $push
+     * @param \Infobip\Model\FlowCommonOttContact[] $facebook
+     * @param \Infobip\Model\FlowCommonOttContact[] $line
+     * @param \Infobip\Model\FlowCommonOttContact[] $viberBots
+     * @param \Infobip\Model\FlowCommonOttContact[] $liveChat
+     * @param \Infobip\Model\FlowCommonOttContact[] $instagram
+     * @param \Infobip\Model\FlowCommonOttContact[] $telegram
+     * @param \Infobip\Model\FlowCommonOttContact[] $appleBusinessChat
+     * @param \Infobip\Model\FlowCommonPushContact[] $webpush
+     * @param \Infobip\Model\FlowCommonOttContact[] $instagramDm
+     * @param \Infobip\Model\FlowCommonOttContact[] $kakaoSangdam
+     */
+    public function __construct(
+        protected ?array $phone = null,
+        protected ?array $email = null,
+        protected ?array $push = null,
+        protected ?array $facebook = null,
+        protected ?array $line = null,
+        protected ?array $viberBots = null,
+        protected ?array $liveChat = null,
+        protected ?array $instagram = null,
+        protected ?array $telegram = null,
+        protected ?array $appleBusinessChat = null,
+        protected ?array $webpush = null,
+        protected ?array $instagramDm = null,
+        protected ?array $kakaoSangdam = null,
+    ) {
+
+    }
+
+
+    /**
+     * @return \Infobip\Model\FlowPhoneContact[]|null
+     */
+    public function getPhone(): ?array
+    {
+        return $this->phone;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowPhoneContact[]|null $phone A list of person's phone numbers. Max 100 numbers per person.
+     */
+    public function setPhone(?array $phone): self
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowEmailContact[]|null
+     */
+    public function getEmail(): ?array
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowEmailContact[]|null $email A list of person's email addresses. Max 100 emails per person.
+     */
+    public function setEmail(?array $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowPushContact[]|null
+     */
+    public function getPush(): ?array
+    {
+        return $this->push;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowPushContact[]|null $push List of person's push registrations.
+     */
+    public function setPush(?array $push): self
+    {
+        $this->push = $push;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getFacebook(): ?array
+    {
+        return $this->facebook;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $facebook A list of person's Messenger destinations.
+     */
+    public function setFacebook(?array $facebook): self
+    {
+        $this->facebook = $facebook;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getLine(): ?array
+    {
+        return $this->line;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $line A list of person's Line destinations.
+     */
+    public function setLine(?array $line): self
+    {
+        $this->line = $line;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getViberBots(): ?array
+    {
+        return $this->viberBots;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $viberBots A list of person's Viber Bots destinations.
+     */
+    public function setViberBots(?array $viberBots): self
+    {
+        $this->viberBots = $viberBots;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getLiveChat(): ?array
+    {
+        return $this->liveChat;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $liveChat A list of person's Live Chat destinations.
+     */
+    public function setLiveChat(?array $liveChat): self
+    {
+        $this->liveChat = $liveChat;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getInstagram(): ?array
+    {
+        return $this->instagram;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $instagram A list of person's Instagram destinations.
+     */
+    public function setInstagram(?array $instagram): self
+    {
+        $this->instagram = $instagram;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getTelegram(): ?array
+    {
+        return $this->telegram;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $telegram A list of person's Telegram destinations.
+     */
+    public function setTelegram(?array $telegram): self
+    {
+        $this->telegram = $telegram;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getAppleBusinessChat(): ?array
+    {
+        return $this->appleBusinessChat;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $appleBusinessChat A list of person's Apple Business Chat destinations.
+     */
+    public function setAppleBusinessChat(?array $appleBusinessChat): self
+    {
+        $this->appleBusinessChat = $appleBusinessChat;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonPushContact[]|null
+     */
+    public function getWebpush(): ?array
+    {
+        return $this->webpush;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonPushContact[]|null $webpush A list of person's web push destinations.
+     */
+    public function setWebpush(?array $webpush): self
+    {
+        $this->webpush = $webpush;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getInstagramDm(): ?array
+    {
+        return $this->instagramDm;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $instagramDm A list of person's Instagram DM destinations.
+     */
+    public function setInstagramDm(?array $instagramDm): self
+    {
+        $this->instagramDm = $instagramDm;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FlowCommonOttContact[]|null
+     */
+    public function getKakaoSangdam(): ?array
+    {
+        return $this->kakaoSangdam;
+    }
+
+    /**
+     * @param \Infobip\Model\FlowCommonOttContact[]|null $kakaoSangdam A list of person's Kakao Sangdam destinations.
+     */
+    public function setKakaoSangdam(?array $kakaoSangdam): self
+    {
+        $this->kakaoSangdam = $kakaoSangdam;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowPersonUniqueField.php
+++ b/Infobip/Model/FlowPersonUniqueField.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FlowPersonUniqueField
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $identifier,
+        #[Assert\NotBlank]
+        protected string $type,
+        protected ?string $sender = null,
+    ) {
+
+    }
+
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier(string $identifier): self
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+    public function getType(): mixed
+    {
+        return $this->type;
+    }
+
+    public function setType($type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getSender(): string|null
+    {
+        return $this->sender;
+    }
+
+    public function setSender(?string $sender): self
+    {
+        $this->sender = $sender;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowPersonUniqueFieldType.php
+++ b/Infobip/Model/FlowPersonUniqueFieldType.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowPersonUniqueFieldType implements EnumInterface
+{
+    public const EMAIL = 'EMAIL';
+    public const PHONE = 'PHONE';
+    public const FACEBOOK = 'FACEBOOK';
+    public const LINE = 'LINE';
+    public const APPLE_BUSINESS_CHAT = 'APPLE_BUSINESS_CHAT';
+
+    public const ALLOWED_VALUES = [
+        'EMAIL',
+        'PHONE',
+        'FACEBOOK',
+        'LINE',
+        'APPLE_BUSINESS_CHAT',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function EMAIL(): FlowPersonUniqueFieldType
+    {
+        return new self('EMAIL');
+    }
+
+    public static function PHONE(): FlowPersonUniqueFieldType
+    {
+        return new self('PHONE');
+    }
+
+    public static function FACEBOOK(): FlowPersonUniqueFieldType
+    {
+        return new self('FACEBOOK');
+    }
+
+    public static function LINE(): FlowPersonUniqueFieldType
+    {
+        return new self('LINE');
+    }
+
+    public static function APPLE_BUSINESS_CHAT(): FlowPersonUniqueFieldType
+    {
+        return new self('APPLE_BUSINESS_CHAT');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FlowPhoneContact.php
+++ b/Infobip/Model/FlowPhoneContact.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowPhoneContact
+{
+    /**
+     */
+    public function __construct(
+        protected ?string $number = null,
+    ) {
+
+    }
+
+
+    public function getNumber(): string|null
+    {
+        return $this->number;
+    }
+
+    public function setNumber(?string $number): self
+    {
+        $this->number = $number;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowPushContact.php
+++ b/Infobip/Model/FlowPushContact.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowPushContact
+{
+    /**
+     * @param array<string,object> $additionalData
+     * @param array<string,object> $systemData
+     */
+    public function __construct(
+        protected ?string $applicationId = null,
+        protected ?string $registrationId = null,
+        protected ?array $additionalData = null,
+        protected ?array $systemData = null,
+        protected ?bool $isPrimary = null,
+    ) {
+
+    }
+
+
+    public function getApplicationId(): string|null
+    {
+        return $this->applicationId;
+    }
+
+    public function setApplicationId(?string $applicationId): self
+    {
+        $this->applicationId = $applicationId;
+        return $this;
+    }
+
+    public function getRegistrationId(): string|null
+    {
+        return $this->registrationId;
+    }
+
+    public function setRegistrationId(?string $registrationId): self
+    {
+        $this->registrationId = $registrationId;
+        return $this;
+    }
+
+    /**
+     * @return array<string,object>|null
+     */
+    public function getAdditionalData()
+    {
+        return $this->additionalData;
+    }
+
+    /**
+     * @param array<string,object>|null $additionalData Unique user ID for a person.
+     */
+    public function setAdditionalData(?array $additionalData): self
+    {
+        $this->additionalData = $additionalData;
+        return $this;
+    }
+
+    /**
+     * @return array<string,object>|null
+     */
+    public function getSystemData()
+    {
+        return $this->systemData;
+    }
+
+    /**
+     * @param array<string,object>|null $systemData System data collected from the user's profile.
+     */
+    public function setSystemData(?array $systemData): self
+    {
+        $this->systemData = $systemData;
+        return $this;
+    }
+
+    public function getIsPrimary(): bool|null
+    {
+        return $this->isPrimary;
+    }
+
+    public function setIsPrimary(?bool $isPrimary): self
+    {
+        $this->isPrimary = $isPrimary;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowSalesforce.php
+++ b/Infobip/Model/FlowSalesforce.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FlowSalesforce
+{
+    /**
+     */
+    public function __construct(
+        protected ?string $leadId = null,
+        protected ?string $contactId = null,
+    ) {
+
+    }
+
+
+    public function getLeadId(): string|null
+    {
+        return $this->leadId;
+    }
+
+    public function setLeadId(?string $leadId): self
+    {
+        $this->leadId = $leadId;
+        return $this;
+    }
+
+    public function getContactId(): string|null
+    {
+        return $this->contactId;
+    }
+
+    public function setContactId(?string $contactId): self
+    {
+        $this->contactId = $contactId;
+        return $this;
+    }
+}

--- a/Infobip/Model/FlowType.php
+++ b/Infobip/Model/FlowType.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FlowType implements EnumInterface
+{
+    public const CUSTOMER = 'CUSTOMER';
+    public const LEAD = 'LEAD';
+
+    public const ALLOWED_VALUES = [
+        'CUSTOMER',
+        'LEAD',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function CUSTOMER(): FlowType
+    {
+        return new self('CUSTOMER');
+    }
+
+    public static function LEAD(): FlowType
+    {
+        return new self('LEAD');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FormsActionAfterSubmission.php
+++ b/Infobip/Model/FormsActionAfterSubmission.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsActionAfterSubmission
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $type,
+        #[Assert\NotBlank]
+        protected string $value,
+    ) {
+
+    }
+
+
+    public function getType(): mixed
+    {
+        return $this->type;
+    }
+
+    public function setType($type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsActionAfterSubmissionType.php
+++ b/Infobip/Model/FormsActionAfterSubmissionType.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FormsActionAfterSubmissionType implements EnumInterface
+{
+    public const REDIRECT = 'REDIRECT';
+    public const MESSAGE = 'MESSAGE';
+
+    public const ALLOWED_VALUES = [
+        'REDIRECT',
+        'MESSAGE',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function REDIRECT(): FormsActionAfterSubmissionType
+    {
+        return new self('REDIRECT');
+    }
+
+    public static function MESSAGE(): FormsActionAfterSubmissionType
+    {
+        return new self('MESSAGE');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FormsComponentType.php
+++ b/Infobip/Model/FormsComponentType.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FormsComponentType implements EnumInterface
+{
+    public const TEXT = 'TEXT';
+    public const TEXTAREA = 'TEXTAREA';
+    public const NUMBER = 'NUMBER';
+    public const DROPDOWN = 'DROPDOWN';
+    public const CHECKBOX = 'CHECKBOX';
+    public const CHECKBOX_GROUP = 'CHECKBOX_GROUP';
+    public const RADIOBUTTON = 'RADIOBUTTON';
+    public const DATE = 'DATE';
+    public const DATETIME = 'DATETIME';
+    public const EMAIL = 'EMAIL';
+    public const MSISDN = 'MSISDN';
+    public const SUBMIT_BUTTON = 'SUBMIT_BUTTON';
+    public const TITLE = 'TITLE';
+    public const DESCRIPTION = 'DESCRIPTION';
+    public const APPLE_SPLASH = 'APPLE_SPLASH';
+    public const APPLE_BOOLEAN = 'APPLE_BOOLEAN';
+    public const WHATSAPP_SCREEN = 'WHATSAPP_SCREEN';
+    public const WHATSAPP_HEADING = 'WHATSAPP_HEADING';
+    public const WHATSAPP_SUBHEADING = 'WHATSAPP_SUBHEADING';
+    public const WHATSAPP_BODY = 'WHATSAPP_BODY';
+
+    public const ALLOWED_VALUES = [
+        'TEXT',
+        'TEXTAREA',
+        'NUMBER',
+        'DROPDOWN',
+        'CHECKBOX',
+        'CHECKBOX_GROUP',
+        'RADIOBUTTON',
+        'DATE',
+        'DATETIME',
+        'EMAIL',
+        'MSISDN',
+        'SUBMIT_BUTTON',
+        'TITLE',
+        'DESCRIPTION',
+        'APPLE_SPLASH',
+        'APPLE_BOOLEAN',
+        'WHATSAPP_SCREEN',
+        'WHATSAPP_HEADING',
+        'WHATSAPP_SUBHEADING',
+        'WHATSAPP_BODY',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function TEXT(): FormsComponentType
+    {
+        return new self('TEXT');
+    }
+
+    public static function TEXTAREA(): FormsComponentType
+    {
+        return new self('TEXTAREA');
+    }
+
+    public static function NUMBER(): FormsComponentType
+    {
+        return new self('NUMBER');
+    }
+
+    public static function DROPDOWN(): FormsComponentType
+    {
+        return new self('DROPDOWN');
+    }
+
+    public static function CHECKBOX(): FormsComponentType
+    {
+        return new self('CHECKBOX');
+    }
+
+    public static function CHECKBOX_GROUP(): FormsComponentType
+    {
+        return new self('CHECKBOX_GROUP');
+    }
+
+    public static function RADIOBUTTON(): FormsComponentType
+    {
+        return new self('RADIOBUTTON');
+    }
+
+    public static function DATE(): FormsComponentType
+    {
+        return new self('DATE');
+    }
+
+    public static function DATETIME(): FormsComponentType
+    {
+        return new self('DATETIME');
+    }
+
+    public static function EMAIL(): FormsComponentType
+    {
+        return new self('EMAIL');
+    }
+
+    public static function MSISDN(): FormsComponentType
+    {
+        return new self('MSISDN');
+    }
+
+    public static function SUBMIT_BUTTON(): FormsComponentType
+    {
+        return new self('SUBMIT_BUTTON');
+    }
+
+    public static function TITLE(): FormsComponentType
+    {
+        return new self('TITLE');
+    }
+
+    public static function DESCRIPTION(): FormsComponentType
+    {
+        return new self('DESCRIPTION');
+    }
+
+    public static function APPLE_SPLASH(): FormsComponentType
+    {
+        return new self('APPLE_SPLASH');
+    }
+
+    public static function APPLE_BOOLEAN(): FormsComponentType
+    {
+        return new self('APPLE_BOOLEAN');
+    }
+
+    public static function WHATSAPP_SCREEN(): FormsComponentType
+    {
+        return new self('WHATSAPP_SCREEN');
+    }
+
+    public static function WHATSAPP_HEADING(): FormsComponentType
+    {
+        return new self('WHATSAPP_HEADING');
+    }
+
+    public static function WHATSAPP_SUBHEADING(): FormsComponentType
+    {
+        return new self('WHATSAPP_SUBHEADING');
+    }
+
+    public static function WHATSAPP_BODY(): FormsComponentType
+    {
+        return new self('WHATSAPP_BODY');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FormsElement.php
+++ b/Infobip/Model/FormsElement.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsElement
+{
+    /**
+     * @param array<string,string> $additionalConfiguration
+     * @param \Infobip\Model\FormsElementOption[] $options
+     * @param array<string,string> $validationMessages
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $component,
+        protected ?string $fieldId = null,
+        protected ?string $personField = null,
+        protected ?string $label = null,
+        protected ?bool $isRequired = null,
+        protected ?bool $isHidden = null,
+        protected ?array $additionalConfiguration = null,
+        protected ?string $textContent = null,
+        protected ?array $options = null,
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FormsValidationRules $validationRules = null,
+        protected ?string $placeholder = null,
+        protected ?string $checkboxText = null,
+        protected ?array $validationMessages = null,
+    ) {
+
+    }
+
+
+    public function getComponent(): mixed
+    {
+        return $this->component;
+    }
+
+    public function setComponent($component): self
+    {
+        $this->component = $component;
+        return $this;
+    }
+
+    public function getFieldId(): string|null
+    {
+        return $this->fieldId;
+    }
+
+    public function setFieldId(?string $fieldId): self
+    {
+        $this->fieldId = $fieldId;
+        return $this;
+    }
+
+    public function getPersonField(): string|null
+    {
+        return $this->personField;
+    }
+
+    public function setPersonField(?string $personField): self
+    {
+        $this->personField = $personField;
+        return $this;
+    }
+
+    public function getLabel(): string|null
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): self
+    {
+        $this->label = $label;
+        return $this;
+    }
+
+    public function getIsRequired(): bool|null
+    {
+        return $this->isRequired;
+    }
+
+    public function setIsRequired(?bool $isRequired): self
+    {
+        $this->isRequired = $isRequired;
+        return $this;
+    }
+
+    public function getIsHidden(): bool|null
+    {
+        return $this->isHidden;
+    }
+
+    public function setIsHidden(?bool $isHidden): self
+    {
+        $this->isHidden = $isHidden;
+        return $this;
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    public function getAdditionalConfiguration()
+    {
+        return $this->additionalConfiguration;
+    }
+
+    /**
+     * @param array<string,string>|null $additionalConfiguration additionalConfiguration
+     */
+    public function setAdditionalConfiguration(?array $additionalConfiguration): self
+    {
+        $this->additionalConfiguration = $additionalConfiguration;
+        return $this;
+    }
+
+    public function getTextContent(): string|null
+    {
+        return $this->textContent;
+    }
+
+    public function setTextContent(?string $textContent): self
+    {
+        $this->textContent = $textContent;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FormsElementOption[]|null
+     */
+    public function getOptions(): ?array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param \Infobip\Model\FormsElementOption[]|null $options options
+     */
+    public function setOptions(?array $options): self
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    public function getValidationRules(): \Infobip\Model\FormsValidationRules|null
+    {
+        return $this->validationRules;
+    }
+
+    public function setValidationRules(?\Infobip\Model\FormsValidationRules $validationRules): self
+    {
+        $this->validationRules = $validationRules;
+        return $this;
+    }
+
+    public function getPlaceholder(): string|null
+    {
+        return $this->placeholder;
+    }
+
+    public function setPlaceholder(?string $placeholder): self
+    {
+        $this->placeholder = $placeholder;
+        return $this;
+    }
+
+    public function getCheckboxText(): string|null
+    {
+        return $this->checkboxText;
+    }
+
+    public function setCheckboxText(?string $checkboxText): self
+    {
+        $this->checkboxText = $checkboxText;
+        return $this;
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    public function getValidationMessages()
+    {
+        return $this->validationMessages;
+    }
+
+    /**
+     * @param array<string,string>|null $validationMessages validationMessages
+     */
+    public function setValidationMessages(?array $validationMessages): self
+    {
+        $this->validationMessages = $validationMessages;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsElementOption.php
+++ b/Infobip/Model/FormsElementOption.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsElementOption
+{
+    /**
+     * @param array<string,string> $additionalConfiguration
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $name,
+        #[Assert\NotBlank]
+        protected string $value,
+        protected ?array $additionalConfiguration = null,
+    ) {
+
+    }
+
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    public function getAdditionalConfiguration()
+    {
+        return $this->additionalConfiguration;
+    }
+
+    /**
+     * @param array<string,string>|null $additionalConfiguration additionalConfiguration
+     */
+    public function setAdditionalConfiguration(?array $additionalConfiguration): self
+    {
+        $this->additionalConfiguration = $additionalConfiguration;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsResponse.php
+++ b/Infobip/Model/FormsResponse.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsResponse
+{
+    /**
+     * @param \Infobip\Model\FormsResponseContent[] $forms
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected array $forms,
+        protected ?int $offset = null,
+        protected ?int $limit = null,
+        protected ?int $total = null,
+    ) {
+
+    }
+
+
+    /**
+     * @return \Infobip\Model\FormsResponseContent[]
+     */
+    public function getForms(): array
+    {
+        return $this->forms;
+    }
+
+    /**
+     * @param \Infobip\Model\FormsResponseContent[] $forms Forms list
+     */
+    public function setForms(array $forms): self
+    {
+        $this->forms = $forms;
+        return $this;
+    }
+
+    public function getOffset(): int|null
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(?int $offset): self
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    public function getLimit(): int|null
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(?int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function getTotal(): int|null
+    {
+        return $this->total;
+    }
+
+    public function setTotal(?int $total): self
+    {
+        $this->total = $total;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsResponseContent.php
+++ b/Infobip/Model/FormsResponseContent.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Serializer\Annotation as Serializer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsResponseContent
+{
+    /**
+     * @param \Infobip\Model\FormsElement[] $elements
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $id,
+        #[Assert\NotBlank]
+        protected string $name,
+        #[Assert\NotBlank]
+        protected array $elements,
+        #[Assert\NotBlank]
+        protected bool $resubmitEnabled,
+        #[Assert\NotBlank]
+        protected string $formType,
+        #[Assert\NotBlank]
+        protected string $formStatus,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $createdAt = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $updatedAt = null,
+        #[Assert\Valid]
+        protected ?\Infobip\Model\FormsActionAfterSubmission $actionAfterSubmission = null,
+    ) {
+
+    }
+
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return \Infobip\Model\FormsElement[]
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * @param \Infobip\Model\FormsElement[] $elements List of form fields
+     */
+    public function setElements(array $elements): self
+    {
+        $this->elements = $elements;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTime|null
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getUpdatedAt(): \DateTime|null
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTime $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    public function getActionAfterSubmission(): \Infobip\Model\FormsActionAfterSubmission|null
+    {
+        return $this->actionAfterSubmission;
+    }
+
+    public function setActionAfterSubmission(?\Infobip\Model\FormsActionAfterSubmission $actionAfterSubmission): self
+    {
+        $this->actionAfterSubmission = $actionAfterSubmission;
+        return $this;
+    }
+
+    public function getResubmitEnabled(): bool
+    {
+        return $this->resubmitEnabled;
+    }
+
+    public function setResubmitEnabled(bool $resubmitEnabled): self
+    {
+        $this->resubmitEnabled = $resubmitEnabled;
+        return $this;
+    }
+
+    public function getFormType(): mixed
+    {
+        return $this->formType;
+    }
+
+    public function setFormType($formType): self
+    {
+        $this->formType = $formType;
+        return $this;
+    }
+
+    public function getFormStatus(): mixed
+    {
+        return $this->formStatus;
+    }
+
+    public function setFormStatus($formStatus): self
+    {
+        $this->formStatus = $formStatus;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsStatus.php
+++ b/Infobip/Model/FormsStatus.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FormsStatus implements EnumInterface
+{
+    public const ACTIVE = 'ACTIVE';
+    public const DISABLED = 'DISABLED';
+    public const DRAFT = 'DRAFT';
+
+    public const ALLOWED_VALUES = [
+        'ACTIVE',
+        'DISABLED',
+        'DRAFT',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function ACTIVE(): FormsStatus
+    {
+        return new self('ACTIVE');
+    }
+
+    public static function DISABLED(): FormsStatus
+    {
+        return new self('DISABLED');
+    }
+
+    public static function DRAFT(): FormsStatus
+    {
+        return new self('DRAFT');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FormsStatusResponse.php
+++ b/Infobip/Model/FormsStatusResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FormsStatusResponse
+{
+    /**
+     */
+    public function __construct(
+        #[Assert\NotBlank]
+        protected string $status,
+    ) {
+
+    }
+
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/Infobip/Model/FormsType.php
+++ b/Infobip/Model/FormsType.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+use InvalidArgumentException;
+
+final class FormsType implements EnumInterface
+{
+    public const OPT_IN = 'OPT_IN';
+    public const OPT_OUT = 'OPT_OUT';
+    public const FACEBOOK = 'FACEBOOK';
+    public const LIVECHAT = 'LIVECHAT';
+    public const APPLE = 'APPLE';
+    public const CSAT = 'CSAT';
+    public const WA_FLOW = 'WA_FLOW';
+
+    public const ALLOWED_VALUES = [
+        'OPT_IN',
+        'OPT_OUT',
+        'FACEBOOK',
+        'LIVECHAT',
+        'APPLE',
+        'CSAT',
+        'WA_FLOW',
+    ];
+
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        if (!\in_array($value, self::ALLOWED_VALUES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid value: %s, allowed values: %s',
+                    $value,
+                    implode(', ', self::ALLOWED_VALUES)
+                )
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public static function OPT_IN(): FormsType
+    {
+        return new self('OPT_IN');
+    }
+
+    public static function OPT_OUT(): FormsType
+    {
+        return new self('OPT_OUT');
+    }
+
+    public static function FACEBOOK(): FormsType
+    {
+        return new self('FACEBOOK');
+    }
+
+    public static function LIVECHAT(): FormsType
+    {
+        return new self('LIVECHAT');
+    }
+
+    public static function APPLE(): FormsType
+    {
+        return new self('APPLE');
+    }
+
+    public static function CSAT(): FormsType
+    {
+        return new self('CSAT');
+    }
+
+    public static function WA_FLOW(): FormsType
+    {
+        return new self('WA_FLOW');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Infobip/Model/FormsValidationRules.php
+++ b/Infobip/Model/FormsValidationRules.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Infobip Client API Libraries OpenAPI Specification
+ *
+ * OpenAPI specification containing public endpoints supported in client API libraries.
+ *
+ * Contact: support@infobip.com
+ *
+ * This class is auto generated from the Infobip OpenAPI specification through the OpenAPI Specification Client API libraries (Re)Generator (OSCAR), powered by the OpenAPI Generator (https://openapi-generator.tech).
+ *
+ * Do not edit manually. To learn how to raise an issue, see the CONTRIBUTING guide or contact us @ support@infobip.com.
+ */
+
+namespace Infobip\Model;
+
+class FormsValidationRules
+{
+    /**
+     * @param string[] $forbiddenSymbols
+     */
+    public function __construct(
+        protected ?string $datePattern = null,
+        protected ?int $maxLength = null,
+        protected ?string $maxValue = null,
+        protected ?string $minValue = null,
+        protected ?string $pattern = null,
+        protected ?string $sample = null,
+        protected ?array $forbiddenSymbols = null,
+    ) {
+
+    }
+
+
+    public function getDatePattern(): string|null
+    {
+        return $this->datePattern;
+    }
+
+    public function setDatePattern(?string $datePattern): self
+    {
+        $this->datePattern = $datePattern;
+        return $this;
+    }
+
+    public function getMaxLength(): int|null
+    {
+        return $this->maxLength;
+    }
+
+    public function setMaxLength(?int $maxLength): self
+    {
+        $this->maxLength = $maxLength;
+        return $this;
+    }
+
+    public function getMaxValue(): string|null
+    {
+        return $this->maxValue;
+    }
+
+    public function setMaxValue(?string $maxValue): self
+    {
+        $this->maxValue = $maxValue;
+        return $this;
+    }
+
+    public function getMinValue(): string|null
+    {
+        return $this->minValue;
+    }
+
+    public function setMinValue(?string $minValue): self
+    {
+        $this->minValue = $minValue;
+        return $this;
+    }
+
+    public function getPattern(): string|null
+    {
+        return $this->pattern;
+    }
+
+    public function setPattern(?string $pattern): self
+    {
+        $this->pattern = $pattern;
+        return $this;
+    }
+
+    public function getSample(): string|null
+    {
+        return $this->sample;
+    }
+
+    public function setSample(?string $sample): self
+    {
+        $this->sample = $sample;
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getForbiddenSymbols(): ?array
+    {
+        return $this->forbiddenSymbols;
+    }
+
+    /**
+     * @param string[]|null $forbiddenSymbols forbiddenSymbols
+     */
+    public function setForbiddenSymbols(?array $forbiddenSymbols): self
+    {
+        $this->forbiddenSymbols = $forbiddenSymbols;
+        return $this;
+    }
+}

--- a/Infobip/Model/MessageError.php
+++ b/Infobip/Model/MessageError.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessageError
 {
     /**

--- a/Infobip/Model/MessagePrice.php
+++ b/Infobip/Model/MessagePrice.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagePrice
 {
     /**

--- a/Infobip/Model/MessageStatus.php
+++ b/Infobip/Model/MessageStatus.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessageStatus
 {
     /**

--- a/Infobip/Model/MessagesApiCarouselTemplateButton.php
+++ b/Infobip/Model/MessagesApiCarouselTemplateButton.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "OPEN_URL" => "\Infobip\Model\MessagesApiCarouselTemplateOpenUrlButton",

--- a/Infobip/Model/MessagesApiCarouselTemplatePhoneNumberButton.php
+++ b/Infobip/Model/MessagesApiCarouselTemplatePhoneNumberButton.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiCarouselTemplatePhoneNumberButton extends MessagesApiCarouselTemplateButton
 {
     public const TYPE = 'PHONE_NUMBER';

--- a/Infobip/Model/MessagesApiInboundEvent.php
+++ b/Infobip/Model/MessagesApiInboundEvent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "event", mapping: [
     "MO" => "\Infobip\Model\MessagesApiWebhookEvent",

--- a/Infobip/Model/MessagesApiInboundTypingStartedEvent.php
+++ b/Infobip/Model/MessagesApiInboundTypingStartedEvent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MessagesApiInboundTypingStartedEvent extends MessagesApiInboundEvent
 {

--- a/Infobip/Model/MessagesApiInboundTypingStoppedEvent.php
+++ b/Infobip/Model/MessagesApiInboundTypingStoppedEvent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MessagesApiInboundTypingStoppedEvent extends MessagesApiInboundEvent
 {

--- a/Infobip/Model/MessagesApiMessageBody.php
+++ b/Infobip/Model/MessagesApiMessageBody.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "AUTHENTICATION_REQUEST" => "\Infobip\Model\MessagesApiMessageAuthenticationRequestBody",

--- a/Infobip/Model/MessagesApiMessageButton.php
+++ b/Infobip/Model/MessagesApiMessageButton.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "OPEN_URL" => "\Infobip\Model\MessagesApiMessageOpenUrlButton",

--- a/Infobip/Model/MessagesApiMessageDeliveryReporting.php
+++ b/Infobip/Model/MessagesApiMessageDeliveryReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiMessageDeliveryReporting
 {
     /**

--- a/Infobip/Model/MessagesApiMessageHeader.php
+++ b/Infobip/Model/MessagesApiMessageHeader.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEXT" => "\Infobip\Model\MessagesApiMessageTextHeader",

--- a/Infobip/Model/MessagesApiMessageRequestLocationButton.php
+++ b/Infobip/Model/MessagesApiMessageRequestLocationButton.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiMessageRequestLocationButton extends MessagesApiMessageButton
 {
     public const TYPE = 'REQUEST_LOCATION';

--- a/Infobip/Model/MessagesApiOutboundEvent.php
+++ b/Infobip/Model/MessagesApiOutboundEvent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "event", mapping: [
     "TYPING_STARTED" => "\Infobip\Model\MessagesApiOutboundTypingStartedEvent",

--- a/Infobip/Model/MessagesApiRequestSchedulingSettings.php
+++ b/Infobip/Model/MessagesApiRequestSchedulingSettings.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MessagesApiRequestSchedulingSettings
 {

--- a/Infobip/Model/MessagesApiSeenStatusReporting.php
+++ b/Infobip/Model/MessagesApiSeenStatusReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiSeenStatusReporting
 {
     /**

--- a/Infobip/Model/MessagesApiTemplateBody.php
+++ b/Infobip/Model/MessagesApiTemplateBody.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "CAROUSEL" => "\Infobip\Model\MessagesApiTemplateCarouselBody",

--- a/Infobip/Model/MessagesApiTemplateButton.php
+++ b/Infobip/Model/MessagesApiTemplateButton.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "CATALOG" => "\Infobip\Model\MessagesApiTemplateCatalogButton",

--- a/Infobip/Model/MessagesApiTemplateCarouselCardHeader.php
+++ b/Infobip/Model/MessagesApiTemplateCarouselCardHeader.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "IMAGE" => "\Infobip\Model\MessagesApiTemplateCarouselCardImageHeader",

--- a/Infobip/Model/MessagesApiTemplateHeader.php
+++ b/Infobip/Model/MessagesApiTemplateHeader.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "DOCUMENT" => "\Infobip\Model\MessagesApiTemplateDocumentHeader",

--- a/Infobip/Model/MessagesApiTemplatePhoneNumberButton.php
+++ b/Infobip/Model/MessagesApiTemplatePhoneNumberButton.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiTemplatePhoneNumberButton extends MessagesApiTemplateButton
 {
     public const TYPE = 'PHONE_NUMBER';

--- a/Infobip/Model/MessagesApiTemplateTextBody.php
+++ b/Infobip/Model/MessagesApiTemplateTextBody.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiTemplateTextBody extends MessagesApiTemplateBody
 {
     public const TYPE = 'TEXT';

--- a/Infobip/Model/MessagesApiTemplateTextHeader.php
+++ b/Infobip/Model/MessagesApiTemplateTextHeader.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiTemplateTextHeader extends MessagesApiTemplateHeader
 {
     public const TYPE = 'TEXT';

--- a/Infobip/Model/MessagesApiWebhookEvent.php
+++ b/Infobip/Model/MessagesApiWebhookEvent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MessagesApiWebhookEvent extends MessagesApiInboundEvent
 {

--- a/Infobip/Model/MessagesApiWebhookEventAuthenticationResponseContent.php
+++ b/Infobip/Model/MessagesApiWebhookEventAuthenticationResponseContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiWebhookEventAuthenticationResponseContent extends MessagesApiWebhookEventContent
 {
     public const TYPE = 'AUTHENTICATION_RESPONSE';

--- a/Infobip/Model/MessagesApiWebhookEventContent.php
+++ b/Infobip/Model/MessagesApiWebhookEventContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "AUDIO" => "\Infobip\Model\MessagesApiWebhookEventAudioContent",

--- a/Infobip/Model/MessagesApiWebhookEventLocationContent.php
+++ b/Infobip/Model/MessagesApiWebhookEventLocationContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MessagesApiWebhookEventLocationContent extends MessagesApiWebhookEventContent
 {
     public const TYPE = 'LOCATION';

--- a/Infobip/Model/MmsInboundDestination.php
+++ b/Infobip/Model/MmsInboundDestination.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundDestination
 {
     /**

--- a/Infobip/Model/MmsInboundDestinationCc.php
+++ b/Infobip/Model/MmsInboundDestinationCc.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundDestinationCc
 {
     /**

--- a/Infobip/Model/MmsInboundDestinationTo.php
+++ b/Infobip/Model/MmsInboundDestinationTo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundDestinationTo
 {
     /**

--- a/Infobip/Model/MmsInboundLinkSegment.php
+++ b/Infobip/Model/MmsInboundLinkSegment.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundLinkSegment
 {
     /**

--- a/Infobip/Model/MmsInboundMessageSegment.php
+++ b/Infobip/Model/MmsInboundMessageSegment.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundMessageSegment
 {
     /**

--- a/Infobip/Model/MmsInboundReportResponse.php
+++ b/Infobip/Model/MmsInboundReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundReportResponse
 {
     /**

--- a/Infobip/Model/MmsInboundTextSegment.php
+++ b/Infobip/Model/MmsInboundTextSegment.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundTextSegment
 {
     /**

--- a/Infobip/Model/MmsInboundWebhookRequest.php
+++ b/Infobip/Model/MmsInboundWebhookRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsInboundWebhookRequest
 {
     /**

--- a/Infobip/Model/MmsInboundWebhookResult.php
+++ b/Infobip/Model/MmsInboundWebhookResult.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MmsInboundWebhookResult
 {

--- a/Infobip/Model/MmsLog.php
+++ b/Infobip/Model/MmsLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MmsLog
 {

--- a/Infobip/Model/MmsLogsResponse.php
+++ b/Infobip/Model/MmsLogsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsLogsResponse
 {
     /**

--- a/Infobip/Model/MmsMessageDeliveryReporting.php
+++ b/Infobip/Model/MmsMessageDeliveryReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsMessageDeliveryReporting
 {
     /**

--- a/Infobip/Model/MmsReport.php
+++ b/Infobip/Model/MmsReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MmsReport
 {

--- a/Infobip/Model/MmsReportResponse.php
+++ b/Infobip/Model/MmsReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsReportResponse
 {
     /**

--- a/Infobip/Model/MmsRequestSchedulingSettings.php
+++ b/Infobip/Model/MmsRequestSchedulingSettings.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MmsRequestSchedulingSettings
 {

--- a/Infobip/Model/MmsSouthKoreaOptions.php
+++ b/Infobip/Model/MmsSouthKoreaOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsSouthKoreaOptions
 {
     /**

--- a/Infobip/Model/MmsUploadBinaryResult.php
+++ b/Infobip/Model/MmsUploadBinaryResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class MmsUploadBinaryResult
 {
     /**

--- a/Infobip/Model/NumberMaskingCallbackRequest.php
+++ b/Infobip/Model/NumberMaskingCallbackRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class NumberMaskingCallbackRequest
 {
     /**

--- a/Infobip/Model/NumberMaskingCredentialsResponse.php
+++ b/Infobip/Model/NumberMaskingCredentialsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class NumberMaskingCredentialsResponse
 {
     /**

--- a/Infobip/Model/NumberMaskingStatusRequest.php
+++ b/Infobip/Model/NumberMaskingStatusRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class NumberMaskingStatusRequest
 {
     /**

--- a/Infobip/Model/NumberMaskingUploadBody.php
+++ b/Infobip/Model/NumberMaskingUploadBody.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class NumberMaskingUploadBody
 {
     /**

--- a/Infobip/Model/NumberMaskingUploadResponse.php
+++ b/Infobip/Model/NumberMaskingUploadResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class NumberMaskingUploadResponse
 {
     /**

--- a/Infobip/Model/RingbackGeneration.php
+++ b/Infobip/Model/RingbackGeneration.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class RingbackGeneration
 {
     /**

--- a/Infobip/Model/SmsBulkRequest.php
+++ b/Infobip/Model/SmsBulkRequest.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsBulkRequest
 {

--- a/Infobip/Model/SmsBulkStatusResponse.php
+++ b/Infobip/Model/SmsBulkStatusResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsBulkStatusResponse
 {
     /**

--- a/Infobip/Model/SmsDeliveryReport.php
+++ b/Infobip/Model/SmsDeliveryReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsDeliveryReport
 {

--- a/Infobip/Model/SmsDeliveryResult.php
+++ b/Infobip/Model/SmsDeliveryResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsDeliveryResult
 {
     /**

--- a/Infobip/Model/SmsInboundMessage.php
+++ b/Infobip/Model/SmsInboundMessage.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsInboundMessage
 {

--- a/Infobip/Model/SmsInboundMessageResult.php
+++ b/Infobip/Model/SmsInboundMessageResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsInboundMessageResult
 {
     /**

--- a/Infobip/Model/SmsLanguage.php
+++ b/Infobip/Model/SmsLanguage.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsLanguage
 {
     /**

--- a/Infobip/Model/SmsLog.php
+++ b/Infobip/Model/SmsLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsLog
 {

--- a/Infobip/Model/SmsLogsResponse.php
+++ b/Infobip/Model/SmsLogsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsLogsResponse
 {
     /**

--- a/Infobip/Model/SmsMessageDeliveryReporting.php
+++ b/Infobip/Model/SmsMessageDeliveryReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsMessageDeliveryReporting
 {
     /**

--- a/Infobip/Model/SmsMessageError.php
+++ b/Infobip/Model/SmsMessageError.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsMessageError
 {
     /**

--- a/Infobip/Model/SmsMessageResponseDetails.php
+++ b/Infobip/Model/SmsMessageResponseDetails.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsMessageResponseDetails
 {
     /**

--- a/Infobip/Model/SmsMessageStatus.php
+++ b/Infobip/Model/SmsMessageStatus.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsMessageStatus
 {
     /**

--- a/Infobip/Model/SmsPreviewLanguage.php
+++ b/Infobip/Model/SmsPreviewLanguage.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsPreviewLanguage
 {
     /**

--- a/Infobip/Model/SmsPreviewResponse.php
+++ b/Infobip/Model/SmsPreviewResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsPreviewResponse
 {
     /**

--- a/Infobip/Model/SmsRequestSchedulingSettings.php
+++ b/Infobip/Model/SmsRequestSchedulingSettings.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsRequestSchedulingSettings
 {

--- a/Infobip/Model/SmsTracking.php
+++ b/Infobip/Model/SmsTracking.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsTracking
 {
     /**

--- a/Infobip/Model/SmsWebhookInboundReport.php
+++ b/Infobip/Model/SmsWebhookInboundReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SmsWebhookInboundReport
 {

--- a/Infobip/Model/SmsWebhookInboundReportResponse.php
+++ b/Infobip/Model/SmsWebhookInboundReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class SmsWebhookInboundReportResponse
 {
     /**

--- a/Infobip/Model/TfaApplicationConfiguration.php
+++ b/Infobip/Model/TfaApplicationConfiguration.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaApplicationConfiguration
 {
     /**

--- a/Infobip/Model/TfaEmailMessage.php
+++ b/Infobip/Model/TfaEmailMessage.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaEmailMessage
 {
     /**

--- a/Infobip/Model/TfaEmailStatus.php
+++ b/Infobip/Model/TfaEmailStatus.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaEmailStatus
 {
     /**

--- a/Infobip/Model/TfaResendPinRequest.php
+++ b/Infobip/Model/TfaResendPinRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaResendPinRequest
 {
     /**

--- a/Infobip/Model/TfaStartAuthenticationResponse.php
+++ b/Infobip/Model/TfaStartAuthenticationResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaStartAuthenticationResponse
 {
     /**

--- a/Infobip/Model/TfaUpdateEmailMessageRequest.php
+++ b/Infobip/Model/TfaUpdateEmailMessageRequest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaUpdateEmailMessageRequest
 {
     /**

--- a/Infobip/Model/TfaVerification.php
+++ b/Infobip/Model/TfaVerification.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaVerification
 {
     /**

--- a/Infobip/Model/TfaVerificationResponse.php
+++ b/Infobip/Model/TfaVerificationResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaVerificationResponse
 {
     /**

--- a/Infobip/Model/TfaVerifyPinResponse.php
+++ b/Infobip/Model/TfaVerifyPinResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class TfaVerifyPinResponse
 {
     /**

--- a/Infobip/Model/UrlOptions.php
+++ b/Infobip/Model/UrlOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class UrlOptions
 {
     /**

--- a/Infobip/Model/ViberInboundContent.php
+++ b/Infobip/Model/ViberInboundContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "FILE" => "\Infobip\Model\ViberInboundFileContent",

--- a/Infobip/Model/ViberInboundFileContent.php
+++ b/Infobip/Model/ViberInboundFileContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberInboundFileContent extends ViberInboundContent
 {
     public const TYPE = 'FILE';

--- a/Infobip/Model/ViberInboundMessageViberInboundContent.php
+++ b/Infobip/Model/ViberInboundMessageViberInboundContent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ViberInboundMessageViberInboundContent
 {

--- a/Infobip/Model/ViberLog.php
+++ b/Infobip/Model/ViberLog.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ViberLog
 {

--- a/Infobip/Model/ViberLogsResponse.php
+++ b/Infobip/Model/ViberLogsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberLogsResponse
 {
     /**

--- a/Infobip/Model/ViberMessageDeliveryReporting.php
+++ b/Infobip/Model/ViberMessageDeliveryReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberMessageDeliveryReporting
 {
     /**

--- a/Infobip/Model/ViberMessageError.php
+++ b/Infobip/Model/ViberMessageError.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberMessageError
 {
     /**

--- a/Infobip/Model/ViberOutboundContent.php
+++ b/Infobip/Model/ViberOutboundContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "FILE" => "\Infobip\Model\ViberOutboundFileContent",

--- a/Infobip/Model/ViberRequestSchedulingSettings.php
+++ b/Infobip/Model/ViberRequestSchedulingSettings.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ViberRequestSchedulingSettings
 {

--- a/Infobip/Model/ViberSeenReports.php
+++ b/Infobip/Model/ViberSeenReports.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberSeenReports
 {
     /**

--- a/Infobip/Model/ViberSeenStatusReporting.php
+++ b/Infobip/Model/ViberSeenStatusReporting.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberSeenStatusReporting
 {
     /**

--- a/Infobip/Model/ViberWebhookInboundReportResponse.php
+++ b/Infobip/Model/ViberWebhookInboundReportResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberWebhookInboundReportResponse
 {
     /**

--- a/Infobip/Model/ViberWebhookReport.php
+++ b/Infobip/Model/ViberWebhookReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ViberWebhookReport
 {

--- a/Infobip/Model/ViberWebhookReportsResponse.php
+++ b/Infobip/Model/ViberWebhookReportsResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class ViberWebhookReportsResponse
 {
     /**

--- a/Infobip/Model/WebRtcBrowserDetectedLocalization.php
+++ b/Infobip/Model/WebRtcBrowserDetectedLocalization.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcBrowserDetectedLocalization extends WebRtcLocalization
 {
     public const TYPE = 'BROWSER_DETECTED';

--- a/Infobip/Model/WebRtcCallLinkResponse.php
+++ b/Infobip/Model/WebRtcCallLinkResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcCallLinkResponse
 {
     /**

--- a/Infobip/Model/WebRtcCallOptions.php
+++ b/Infobip/Model/WebRtcCallOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcCallOptions
 {
     /**

--- a/Infobip/Model/WebRtcCapabilities.php
+++ b/Infobip/Model/WebRtcCapabilities.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcCapabilities
 {
     /**

--- a/Infobip/Model/WebRtcColors.php
+++ b/Infobip/Model/WebRtcColors.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcColors
 {
     /**

--- a/Infobip/Model/WebRtcConversationsDestination.php
+++ b/Infobip/Model/WebRtcConversationsDestination.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcConversationsDestination extends WebRtcDestination
 {
     public const TYPE = 'CONVERSATIONS';

--- a/Infobip/Model/WebRtcErrorCode.php
+++ b/Infobip/Model/WebRtcErrorCode.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcErrorCode
 {
     /**

--- a/Infobip/Model/WebRtcFile.php
+++ b/Infobip/Model/WebRtcFile.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcFile
 {
     /**

--- a/Infobip/Model/WebRtcImageResponse.php
+++ b/Infobip/Model/WebRtcImageResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcImageResponse
 {
     /**

--- a/Infobip/Model/WebRtcImages.php
+++ b/Infobip/Model/WebRtcImages.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcImages
 {
     /**

--- a/Infobip/Model/WebRtcInitialOptions.php
+++ b/Infobip/Model/WebRtcInitialOptions.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcInitialOptions
 {
     /**

--- a/Infobip/Model/WebRtcMessages.php
+++ b/Infobip/Model/WebRtcMessages.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcMessages
 {
     /**

--- a/Infobip/Model/WebRtcParticipant.php
+++ b/Infobip/Model/WebRtcParticipant.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WebRtcParticipant
 {

--- a/Infobip/Model/WebRtcPushConfigurationResponse.php
+++ b/Infobip/Model/WebRtcPushConfigurationResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcPushConfigurationResponse
 {
     /**

--- a/Infobip/Model/WebRtcSubdomainPage.php
+++ b/Infobip/Model/WebRtcSubdomainPage.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcSubdomainPage
 {
     /**

--- a/Infobip/Model/WebRtcSubdomainResponse.php
+++ b/Infobip/Model/WebRtcSubdomainResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcSubdomainResponse
 {
     /**

--- a/Infobip/Model/WebRtcTokenResponseModel.php
+++ b/Infobip/Model/WebRtcTokenResponseModel.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebRtcTokenResponseModel
 {
     /**

--- a/Infobip/Model/WebRtcValidityWindow.php
+++ b/Infobip/Model/WebRtcValidityWindow.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WebRtcValidityWindow
 {

--- a/Infobip/Model/WebhookMessageCount.php
+++ b/Infobip/Model/WebhookMessageCount.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WebhookMessageCount
 {
     /**

--- a/Infobip/Model/WebhookReport.php
+++ b/Infobip/Model/WebhookReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WebhookReport
 {

--- a/Infobip/Model/WhatsAppAddressContent.php
+++ b/Infobip/Model/WhatsAppAddressContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppAddressContent
 {
     /**

--- a/Infobip/Model/WhatsAppAuthenticationBodyApiData.php
+++ b/Infobip/Model/WhatsAppAuthenticationBodyApiData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppAuthenticationBodyApiData
 {
     /**

--- a/Infobip/Model/WhatsAppAuthenticationButtonApiData.php
+++ b/Infobip/Model/WhatsAppAuthenticationButtonApiData.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "otpType", mapping: [
     "COPY_CODE" => "\Infobip\Model\WhatsAppCopyCodeButtonApiData",

--- a/Infobip/Model/WhatsAppAuthenticationTemplateApiResponse.php
+++ b/Infobip/Model/WhatsAppAuthenticationTemplateApiResponse.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
+use Symfony\Component\Serializer\Annotation as Serializer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppAuthenticationTemplateApiResponse extends WhatsAppTemplateApiResponse
@@ -36,6 +38,10 @@ class WhatsAppAuthenticationTemplateApiResponse extends WhatsAppTemplateApiRespo
         protected ?string $quality = null,
         #[Assert\Valid]
         protected ?\Infobip\Model\Platform $platform = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $createdAt = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $lastUpdatedAt = null,
         #[Assert\Valid]
         protected ?\Infobip\Model\WhatsAppValidityPeriodApiData $validityPeriod = null,
     ) {
@@ -51,6 +57,8 @@ class WhatsAppAuthenticationTemplateApiResponse extends WhatsAppTemplateApiRespo
             structure: $structure,
             quality: $quality,
             platform: $platform,
+            createdAt: $createdAt,
+            lastUpdatedAt: $lastUpdatedAt,
         );
     }
 

--- a/Infobip/Model/WhatsAppBulkMessageInfo.php
+++ b/Infobip/Model/WhatsAppBulkMessageInfo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppBulkMessageInfo
 {
     /**

--- a/Infobip/Model/WhatsAppDefaultMarketingTemplateApiResponse.php
+++ b/Infobip/Model/WhatsAppDefaultMarketingTemplateApiResponse.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
+use Symfony\Component\Serializer\Annotation as Serializer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppDefaultMarketingTemplateApiResponse extends WhatsAppTemplateApiResponse
@@ -36,6 +38,10 @@ class WhatsAppDefaultMarketingTemplateApiResponse extends WhatsAppTemplateApiRes
         protected ?string $quality = null,
         #[Assert\Valid]
         protected ?\Infobip\Model\Platform $platform = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $createdAt = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $lastUpdatedAt = null,
     ) {
         $modelDiscriminatorValue = self::CATEGORY;
 
@@ -49,6 +55,8 @@ class WhatsAppDefaultMarketingTemplateApiResponse extends WhatsAppTemplateApiRes
             structure: $structure,
             quality: $quality,
             platform: $platform,
+            createdAt: $createdAt,
+            lastUpdatedAt: $lastUpdatedAt,
         );
     }
 

--- a/Infobip/Model/WhatsAppDefaultUtilityTemplateApiResponse.php
+++ b/Infobip/Model/WhatsAppDefaultUtilityTemplateApiResponse.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
+use Symfony\Component\Serializer\Annotation as Serializer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppDefaultUtilityTemplateApiResponse extends WhatsAppTemplateApiResponse
@@ -36,6 +38,10 @@ class WhatsAppDefaultUtilityTemplateApiResponse extends WhatsAppTemplateApiRespo
         protected ?string $quality = null,
         #[Assert\Valid]
         protected ?\Infobip\Model\Platform $platform = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $createdAt = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $lastUpdatedAt = null,
     ) {
         $modelDiscriminatorValue = self::CATEGORY;
 
@@ -49,6 +55,8 @@ class WhatsAppDefaultUtilityTemplateApiResponse extends WhatsAppTemplateApiRespo
             structure: $structure,
             quality: $quality,
             platform: $platform,
+            createdAt: $createdAt,
+            lastUpdatedAt: $lastUpdatedAt,
         );
     }
 

--- a/Infobip/Model/WhatsAppDocumentHeaderApiData.php
+++ b/Infobip/Model/WhatsAppDocumentHeaderApiData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppDocumentHeaderApiData extends WhatsAppHeaderApiData
 {
     public const FORMAT = 'DOCUMENT';

--- a/Infobip/Model/WhatsAppEmailContent.php
+++ b/Infobip/Model/WhatsAppEmailContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppEmailContent
 {
     /**

--- a/Infobip/Model/WhatsAppIdentityInfo.php
+++ b/Infobip/Model/WhatsAppIdentityInfo.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppIdentityInfo
 {

--- a/Infobip/Model/WhatsAppImageHeaderApiData.php
+++ b/Infobip/Model/WhatsAppImageHeaderApiData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppImageHeaderApiData extends WhatsAppHeaderApiData
 {
     public const FORMAT = 'IMAGE';

--- a/Infobip/Model/WhatsAppInteractiveAllowedOrderPaymentDetails.php
+++ b/Infobip/Model/WhatsAppInteractiveAllowedOrderPaymentDetails.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "BRAZIL" => "\Infobip\Model\WhatsAppInteractiveOrderBrazilPaymentDetails",

--- a/Infobip/Model/WhatsAppInteractiveButtonContent.php
+++ b/Infobip/Model/WhatsAppInteractiveButtonContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "REPLY" => "\Infobip\Model\WhatsAppInteractiveReplyButtonContent",

--- a/Infobip/Model/WhatsAppInteractiveButtonsHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveButtonsHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "DOCUMENT" => "\Infobip\Model\WhatsAppInteractiveButtonsDocumentHeaderContent",

--- a/Infobip/Model/WhatsAppInteractiveFlowHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveFlowHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEXT" => "\Infobip\Model\WhatsAppInteractiveFlowTextHeaderContent",

--- a/Infobip/Model/WhatsAppInteractiveListHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveListHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEXT" => "\Infobip\Model\WhatsAppInteractiveListTextHeaderContent",

--- a/Infobip/Model/WhatsAppInteractiveMultiProductHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveMultiProductHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEXT" => "\Infobip\Model\WhatsAppInteractiveMultiProductTextHeaderContent",

--- a/Infobip/Model/WhatsAppInteractiveOrderDetailsHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveOrderDetailsHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "IMAGE" => "\Infobip\Model\WhatsAppInteractiveOrderDetailsImageHeaderContent",

--- a/Infobip/Model/WhatsAppInteractiveOrderDetailsImporterAddress.php
+++ b/Infobip/Model/WhatsAppInteractiveOrderDetailsImporterAddress.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppInteractiveOrderDetailsImporterAddress
 {
     /**

--- a/Infobip/Model/WhatsAppInteractiveOrderPaymentStatus.php
+++ b/Infobip/Model/WhatsAppInteractiveOrderPaymentStatus.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "BRAZIL" => "\Infobip\Model\WhatsAppInteractiveOrderBrazilPaymentStatus",

--- a/Infobip/Model/WhatsAppInteractiveUrlButtonHeaderContent.php
+++ b/Infobip/Model/WhatsAppInteractiveUrlButtonHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEXT" => "\Infobip\Model\WhatsAppInteractiveUrlButtonTextHeaderContent",

--- a/Infobip/Model/WhatsAppLocationHeaderApiData.php
+++ b/Infobip/Model/WhatsAppLocationHeaderApiData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppLocationHeaderApiData extends WhatsAppHeaderApiData
 {
     public const FORMAT = 'LOCATION';

--- a/Infobip/Model/WhatsAppMarkAsReadErrorResponse.php
+++ b/Infobip/Model/WhatsAppMarkAsReadErrorResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppMarkAsReadErrorResponse
 {
     /**

--- a/Infobip/Model/WhatsAppOrganizationContent.php
+++ b/Infobip/Model/WhatsAppOrganizationContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppOrganizationContent
 {
     /**

--- a/Infobip/Model/WhatsAppPaymentTransaction.php
+++ b/Infobip/Model/WhatsAppPaymentTransaction.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppPaymentTransaction
 {

--- a/Infobip/Model/WhatsAppPhoneContent.php
+++ b/Infobip/Model/WhatsAppPhoneContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppPhoneContent
 {
     /**

--- a/Infobip/Model/WhatsAppSenderLimit.php
+++ b/Infobip/Model/WhatsAppSenderLimit.php
@@ -21,7 +21,6 @@ use InvalidArgumentException;
 final class WhatsAppSenderLimit implements EnumInterface
 {
     public const LIMIT_NA = 'LIMIT_NA';
-    public const LIMIT_50 = 'LIMIT_50';
     public const LIMIT_250 = 'LIMIT_250';
     public const LIMIT_1_K = 'LIMIT_1K';
     public const LIMIT_10_K = 'LIMIT_10K';
@@ -30,7 +29,6 @@ final class WhatsAppSenderLimit implements EnumInterface
 
     public const ALLOWED_VALUES = [
         'LIMIT_NA',
-        'LIMIT_50',
         'LIMIT_250',
         'LIMIT_1K',
         'LIMIT_10K',
@@ -58,11 +56,6 @@ final class WhatsAppSenderLimit implements EnumInterface
     public static function LIMIT_NA(): WhatsAppSenderLimit
     {
         return new self('LIMIT_NA');
-    }
-
-    public static function LIMIT_50(): WhatsAppSenderLimit
-    {
-        return new self('LIMIT_50');
     }
 
     public static function LIMIT_250(): WhatsAppSenderLimit

--- a/Infobip/Model/WhatsAppSenderQuality.php
+++ b/Infobip/Model/WhatsAppSenderQuality.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppSenderQuality
 {

--- a/Infobip/Model/WhatsAppSingleMessageStatus.php
+++ b/Infobip/Model/WhatsAppSingleMessageStatus.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppSingleMessageStatus
 {
     /**

--- a/Infobip/Model/WhatsAppTemplateAllowedOrderPaymentDetails.php
+++ b/Infobip/Model/WhatsAppTemplateAllowedOrderPaymentDetails.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "BRAZIL_LINK" => "\Infobip\Model\WhatsAppInteractiveOrderBrazilLinkPaymentDetails",

--- a/Infobip/Model/WhatsAppTemplateApiResponse.php
+++ b/Infobip/Model/WhatsAppTemplateApiResponse.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "category", mapping: [
     "AUTHENTICATION" => "\Infobip\Model\WhatsAppAuthenticationTemplateApiResponse",
@@ -42,6 +44,10 @@ class WhatsAppTemplateApiResponse
         protected ?string $quality = null,
         #[Assert\Valid]
         protected ?\Infobip\Model\Platform $platform = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $createdAt = null,
+        #[Serializer\Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\TH:i:s.vP'])]
+        protected ?\DateTime $lastUpdatedAt = null,
     ) {
 
     }
@@ -143,6 +149,28 @@ class WhatsAppTemplateApiResponse
     public function setPlatform(?\Infobip\Model\Platform $platform): self
     {
         $this->platform = $platform;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTime|null
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getLastUpdatedAt(): \DateTime|null
+    {
+        return $this->lastUpdatedAt;
+    }
+
+    public function setLastUpdatedAt(?\DateTime $lastUpdatedAt): self
+    {
+        $this->lastUpdatedAt = $lastUpdatedAt;
         return $this;
     }
 }

--- a/Infobip/Model/WhatsAppTemplateButtonContent.php
+++ b/Infobip/Model/WhatsAppTemplateButtonContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "CATALOG" => "\Infobip\Model\WhatsAppTemplateCatalogButtonContent",

--- a/Infobip/Model/WhatsAppTemplateHeaderContent.php
+++ b/Infobip/Model/WhatsAppTemplateHeaderContent.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "DOCUMENT" => "\Infobip\Model\WhatsAppTemplateDocumentHeaderContent",

--- a/Infobip/Model/WhatsAppTemplateLimitedTimeOfferContent.php
+++ b/Infobip/Model/WhatsAppTemplateLimitedTimeOfferContent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppTemplateLimitedTimeOfferContent
 {

--- a/Infobip/Model/WhatsAppTemplatePublicApiRequest.php
+++ b/Infobip/Model/WhatsAppTemplatePublicApiRequest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "category", mapping: [
     "AUTHENTICATION" => "\Infobip\Model\WhatsAppAuthenticationTemplatePublicApiRequest",

--- a/Infobip/Model/WhatsAppTemplatePushEventChange.php
+++ b/Infobip/Model/WhatsAppTemplatePushEventChange.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "TEMPLATE_CATEGORY_UPDATE" => "\Infobip\Model\WhatsAppTemplateCategoryPushEventChange",

--- a/Infobip/Model/WhatsAppTemplateUpdatePushEvent.php
+++ b/Infobip/Model/WhatsAppTemplateUpdatePushEvent.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppTemplateUpdatePushEvent
 {

--- a/Infobip/Model/WhatsAppTemplatesApiResponse.php
+++ b/Infobip/Model/WhatsAppTemplatesApiResponse.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppTemplatesApiResponse
 {
     /**

--- a/Infobip/Model/WhatsAppUrlContent.php
+++ b/Infobip/Model/WhatsAppUrlContent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppUrlContent
 {
     /**

--- a/Infobip/Model/WhatsAppVideoHeaderApiData.php
+++ b/Infobip/Model/WhatsAppVideoHeaderApiData.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppVideoHeaderApiData extends WhatsAppHeaderApiData
 {
     public const FORMAT = 'VIDEO';

--- a/Infobip/Model/WhatsAppWebhookAddress.php
+++ b/Infobip/Model/WhatsAppWebhookAddress.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookAddress
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookContact.php
+++ b/Infobip/Model/WhatsAppWebhookContact.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookContact
 {

--- a/Infobip/Model/WhatsAppWebhookContactName.php
+++ b/Infobip/Model/WhatsAppWebhookContactName.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookContactName
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookDeliveryReport.php
+++ b/Infobip/Model/WhatsAppWebhookDeliveryReport.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookDeliveryReport
 {

--- a/Infobip/Model/WhatsAppWebhookDeliveryResult.php
+++ b/Infobip/Model/WhatsAppWebhookDeliveryResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookDeliveryResult
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookEmail.php
+++ b/Infobip/Model/WhatsAppWebhookEmail.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookEmail
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookInboundMessage.php
+++ b/Infobip/Model/WhatsAppWebhookInboundMessage.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[DiscriminatorMap(typeProperty: "type", mapping: [
     "AUDIO" => "\Infobip\Model\WhatsAppWebhookInboundAudioMessage",

--- a/Infobip/Model/WhatsAppWebhookInboundMessageBase.php
+++ b/Infobip/Model/WhatsAppWebhookInboundMessageBase.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookInboundMessageBase
 {

--- a/Infobip/Model/WhatsAppWebhookInboundMessageData.php
+++ b/Infobip/Model/WhatsAppWebhookInboundMessageData.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookInboundMessageData
 {

--- a/Infobip/Model/WhatsAppWebhookInboundMessageResult.php
+++ b/Infobip/Model/WhatsAppWebhookInboundMessageResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookInboundMessageResult
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookMedia.php
+++ b/Infobip/Model/WhatsAppWebhookMedia.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookMedia
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookName.php
+++ b/Infobip/Model/WhatsAppWebhookName.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookName
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookOrganization.php
+++ b/Infobip/Model/WhatsAppWebhookOrganization.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookOrganization
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookPaymentNotificationResponse.php
+++ b/Infobip/Model/WhatsAppWebhookPaymentNotificationResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookPaymentNotificationResponse
 {

--- a/Infobip/Model/WhatsAppWebhookPaymentTransactionNotification.php
+++ b/Infobip/Model/WhatsAppWebhookPaymentTransactionNotification.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookPaymentTransactionNotification
 {

--- a/Infobip/Model/WhatsAppWebhookPhone.php
+++ b/Infobip/Model/WhatsAppWebhookPhone.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookPhone
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookReferralMediaImage.php
+++ b/Infobip/Model/WhatsAppWebhookReferralMediaImage.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookReferralMediaImage extends WhatsAppWebhookReferralMedia
 {
     public const TYPE = 'IMAGE';

--- a/Infobip/Model/WhatsAppWebhookReferralMediaVideo.php
+++ b/Infobip/Model/WhatsAppWebhookReferralMediaVideo.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookReferralMediaVideo extends WhatsAppWebhookReferralMedia
 {
     public const TYPE = 'VIDEO';

--- a/Infobip/Model/WhatsAppWebhookSeenResult.php
+++ b/Infobip/Model/WhatsAppWebhookSeenResult.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookSeenResult
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookSystemEvent.php
+++ b/Infobip/Model/WhatsAppWebhookSystemEvent.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookSystemEvent
 {
     /**

--- a/Infobip/Model/WhatsAppWebhookSystemEventResponse.php
+++ b/Infobip/Model/WhatsAppWebhookSystemEventResponse.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation as Serializer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class WhatsAppWebhookSystemEventResponse
 {

--- a/Infobip/Model/WhatsAppWebhookUrl.php
+++ b/Infobip/Model/WhatsAppWebhookUrl.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Infobip\Model;
 
-
 class WhatsAppWebhookUrl
 {
     /**

--- a/Infobip/ObjectSerializer.php
+++ b/Infobip/ObjectSerializer.php
@@ -41,10 +41,10 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 
 final class ObjectSerializer
 {

--- a/Infobip/SplFileObjectNormalizer.php
+++ b/Infobip/SplFileObjectNormalizer.php
@@ -27,11 +27,11 @@ namespace Infobip;
 
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
+use SplFileObject;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use SplFileObject;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class SplFileObjectNormalizer implements
     NormalizerInterface,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The current version of this library includes this subset of Infobip products:
 * [Email](https://www.infobip.com/docs/api/channels/email)
 * [WhatsApp](https://www.infobip.com/docs/api/channels/whatsapp)
 * [Viber](https://www.infobip.com/docs/api/channels/viber)
+* [Moments](https://www.infobip.com/docs/api/customer-engagement/moments)
 
 ## General Info
 For `infobip-api-php-client` versioning we use [Semantic Versioning][semver] scheme.
@@ -45,7 +46,7 @@ The library requires PHP version >= 8.3.
 To start using the library add it as dependency in your `composer.json` file like shown below.
 ```json
 "require": {
-	"infobip/infobip-api-php-client": "6.0.0"
+	"infobip/infobip-api-php-client": "6.1.0"
 }
 ```
 And simply run `composer install` to download dependencies.
@@ -220,6 +221,12 @@ For send email quick start guide please check [these examples](email.md).
 
 #### WhatsApp
 For WhatsApp quick start guide, view [these examples](whatsapp.md).
+
+#### Messages API
+For Messages API quick start guide, view [these examples](messages-api.md).
+
+#### Moments
+For Moments quick start guide, view [these examples](moments.md).
 
 ## Ask for help
 

--- a/Test/Api/Moments/FlowApiTest.php
+++ b/Test/Api/Moments/FlowApiTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Infobip\Test\Api\Moments;
+
+use GuzzleHttp\Psr7\Query;
+use Infobip\Api\FlowApi;
+use Infobip\ApiException;
+use Infobip\Model\FlowAddFlowParticipantResult;
+use Infobip\Model\FlowAddFlowParticipantsRequest;
+use Infobip\Model\FlowAddFlowParticipantsResponse;
+use Infobip\Model\FlowEmailContact;
+use Infobip\Model\FlowExceptionResponse;
+use Infobip\Model\FlowParticipant;
+use Infobip\Model\FlowParticipantsReportResponse;
+use Infobip\Model\FlowPerson;
+use Infobip\Model\FlowPersonContacts;
+use Infobip\Model\FlowPersonUniqueField;
+use Infobip\Model\FlowPersonUniqueFieldType;
+use Infobip\Test\Api\ApiTestBase;
+
+class FlowApiTest extends ApiTestBase
+{
+    public function testAddParticipantsToFlow()
+    {
+        $givenRequest = <<<JSON
+        {
+          "participants": [
+            {
+              "identifyBy": {
+                "identifier": "370329180020364",
+                "type": "FACEBOOK"
+              }
+            },
+            {
+              "identifyBy": {
+                "identifier": "test1@example.com",
+                "type": "EMAIL"
+              },
+              "variables": {
+                "orderNumber": 1167873391
+              }
+            },
+            {
+              "identifyBy": {
+                "identifier": "test2@example.com",
+                "type": "EMAIL"
+              },
+              "variables": {
+                "orderNumber": 1595299041
+              },
+              "person": {
+                "externalId": "optional_external_person_id",
+                "customAttributes": {
+                  "Contract Expiry": "2025-04-01",
+                  "Company": "Infobip"
+                },
+                "contactInformation": {
+                  "email": [
+                    {
+                      "address": "info@example.com"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "notifyUrl": "https://example.com/callback",
+          "callbackData": "Callback Data"
+        }
+        JSON;
+
+        $givenResponse = <<<JSON
+        {
+          "operationId": "03f2d474-0508-46bf-9f3d-d8e2c28adaea"
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $flowApi = new FlowApi($this->getConfiguration(), client: $client);
+        $expectedPath = '/moments/1/flows/200000000000001/participants';
+
+        $request = new FlowAddFlowParticipantsRequest(
+            participants: [
+                new FlowParticipant(
+                    identifyBy: new FlowPersonUniqueField(
+                        identifier: '370329180020364',
+                        type: FlowPersonUniqueFieldType::FACEBOOK
+                    )
+                ),
+                new FlowParticipant(
+                    identifyBy: new FlowPersonUniqueField(
+                        identifier: 'test1@example.com',
+                        type: FlowPersonUniqueFieldType::EMAIL
+                    ),
+                    variables: ['orderNumber' => 1167873391]
+                ),
+                new FlowParticipant(
+                    identifyBy: new FlowPersonUniqueField(
+                        identifier: 'test2@example.com',
+                        type: FlowPersonUniqueFieldType::EMAIL
+                    ),
+                    variables: ['orderNumber' => 1595299041],
+                    person: new FlowPerson(
+                        externalId: 'optional_external_person_id',
+                        customAttributes: [
+                            'Contract Expiry' => '2025-04-01',
+                            'Company' => 'Infobip'
+                        ],
+                        contactInformation: new FlowPersonContacts(
+                            email: [
+                                new FlowEmailContact(
+                                    address: 'info@example.com'
+                                )
+                            ]
+                        )
+                    )
+                )
+            ],
+            notifyUrl: 'https://example.com/callback',
+            callbackData: 'Callback Data'
+        );
+
+        $closures = [
+            fn () => $flowApi->addFlowParticipants(
+                '200000000000001',
+                $request
+            ),
+            fn () => $flowApi->addFlowParticipantsAsync(
+                '200000000000001',
+                $request
+            )
+        ];
+
+        $expectedResponse = new FlowAddFlowParticipantsResponse(
+            operationId: '03f2d474-0508-46bf-9f3d-d8e2c28adaea'
+        );
+
+        $this->assertPostRequest(
+            $closures,
+            $expectedPath,
+            $givenRequest,
+            $expectedResponse,
+            $requestHistoryContainer
+        );
+    }
+
+    public function testGetFlowParticipantsAddedResponse()
+    {
+        $givenResponse = <<<JSON
+        {
+          "operationId": "03f2d474-0508-46bf-9f3d-d8e2c28adaea",
+          "campaignId": 200000000000001,
+          "callbackData": "Callback Data",
+          "participants": [
+            {
+              "identifyBy": {
+                "identifier": "test1@example.com",
+                "type": "EMAIL"
+              },
+              "status": "ACCEPTED"
+            },
+            {
+              "identifyBy": {
+                "identifier": "test2@example.com",
+                "type": "EMAIL"
+              },
+              "status": "REJECTED",
+              "errorReason": "REJECTED_INVALID_CONTACT"
+            }
+          ]
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $flowApi = new FlowApi($this->getConfiguration(), client: $client);
+        $expectedPath = '/moments/1/flows/200000000000001/participants/report?'
+            . Query::build(['operationId' => '03f2d474-0508-46bf-9f3d-d8e2c28adaea']);
+
+        $closures = [
+            fn () => $flowApi->getFlowParticipantsAddedReport('200000000000001', '03f2d474-0508-46bf-9f3d-d8e2c28adaea'),
+            fn () => $flowApi->getFlowParticipantsAddedReportAsync('200000000000001', '03f2d474-0508-46bf-9f3d-d8e2c28adaea')
+        ];
+
+        $expectedResponse = new FlowParticipantsReportResponse(
+            operationId: '03f2d474-0508-46bf-9f3d-d8e2c28adaea',
+            campaignId: 200000000000001,
+            participants: [
+                new FlowAddFlowParticipantResult(
+                    identifyBy: new FlowPersonUniqueField(
+                        identifier: 'test1@example.com',
+                        type: FlowPersonUniqueFieldType::EMAIL
+                    ),
+                    status: 'ACCEPTED'
+                ),
+                new FlowAddFlowParticipantResult(
+                    identifyBy: new FlowPersonUniqueField(
+                        identifier: 'test2@example.com',
+                        type: FlowPersonUniqueFieldType::EMAIL
+                    ),
+                    status: 'REJECTED',
+                    errorReason: 'REJECTED_INVALID_CONTACT'
+                )
+            ],
+            callbackData: 'Callback Data'
+        );
+
+        $this->assertGetRequest(
+            $closures,
+            $expectedPath,
+            $expectedResponse,
+            $requestHistoryContainer
+        );
+    }
+
+    public function testRemovingPeopleFromFlow()
+    {
+        $givenCampaignId = '200000000000001';
+        $givenExternalId = '8edb24b5-0319-48cd-a1d9-1e8bc5d577ab';
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, null, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $flowApi = new FlowApi($this->getConfiguration(), client: $client);
+        $expectedPath = "/communication/1/flows/200000000000001/participants?"
+            . Query::build(['externalId' => '8edb24b5-0319-48cd-a1d9-1e8bc5d577ab']);
+
+        $closures = [
+            fn () => $flowApi->removePeopleFromFlow($givenCampaignId, null, null, $givenExternalId),
+            fn () => $flowApi->removePeopleFromFlowAsync($givenCampaignId, null, null, $givenExternalId)
+        ];
+
+        foreach ($closures as $index => $closure) {
+            $this->getUnpackedModel($closure(), null, $requestHistoryContainer);
+
+            $this->assertRequestWithHeaders(
+                'DELETE',
+                $expectedPath,
+                $requestHistoryContainer[$index],
+                ["Accept" => 'application/json',]
+            );
+        }
+    }
+
+    public function testRemovingPeopleFromFlowOnInvalidRequest()
+    {
+        $givenCampaignId = '200000000000001';
+        $givenExternalId = '8edb24b5-0319-48cd-a1d9-1e8bc5d577ab';
+
+        $givenResponse = <<<JSON
+        {
+          "errorCode": 40001,
+          "errorMessage": "Bad request."
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 400);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $flowApi = new FlowApi($this->getConfiguration(), client: $client);
+        $expectedPath = "/communication/1/flows/200000000000001/participants?"
+            . Query::build(['externalId' => '8edb24b5-0319-48cd-a1d9-1e8bc5d577ab']);
+
+        try {
+            $flowApi->removePeopleFromFlow($givenCampaignId, null, null, $givenExternalId);
+        } catch (ApiException $e) {
+            $this->assertEquals(400, $e->getCode());
+            $this->assertInstanceOf(FlowExceptionResponse::class, $e->getResponseObject());
+            /** @var FlowExceptionResponse $response */
+            $response = $e->getResponseObject();
+            $this->assertEquals(40001, $response->getErrorCode());
+            $this->assertEquals('Bad request.', $response->getErrorMessage());
+        }
+
+        $this->assertRequestWithHeaders(
+            'DELETE',
+            $expectedPath,
+            $requestHistoryContainer[0],
+            ["Accept" => 'application/json']
+        );
+    }
+}

--- a/Test/Api/Moments/FormsApiTest.php
+++ b/Test/Api/Moments/FormsApiTest.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace Infobip\Test\Api\Moments;
+
+use DateTime;
+use GuzzleHttp\Psr7\Query;
+use Infobip\Api\FormsApi;
+use Infobip\Model\FormsElement;
+use Infobip\Model\FormsResponse;
+use Infobip\Model\FormsResponseContent;
+use Infobip\Model\FormsStatus;
+use Infobip\Model\FormsStatusResponse;
+use Infobip\Model\FormsType;
+use Infobip\Model\FormsValidationRules;
+use Infobip\Test\Api\ApiTestBase;
+
+class FormsApiTest extends ApiTestBase
+{
+    public function testGetForms()
+    {
+        $givenResponse = <<<JSON
+        {
+          "forms": [
+            {
+              "id": "f23f0f7c-9898-4feb-8f21-5afe2c29db7e",
+              "name": "Test form",
+              "elements": [
+                {
+                  "component": "TEXT",
+                  "fieldId": "first_name",
+                  "personField": "firstName",
+                  "label": "First Name",
+                  "isRequired": false,
+                  "isHidden": false,
+                  "additionalConfiguration": {},
+                  "validationRules": {
+                    "maxLength": 255,
+                    "sample": "James",
+                    "forbiddenSymbols": [
+                      "^",
+                      "&",
+                      "<",
+                      ">"
+                    ]
+                  },
+                  "placeholder": "First Name"
+                },
+                {
+                  "component": "TEXT",
+                  "fieldId": "last_name",
+                  "personField": "lastName",
+                  "label": "Last Name",
+                  "isRequired": false,
+                  "isHidden": false,
+                  "additionalConfiguration": {},
+                  "validationRules": {
+                    "maxLength": 255,
+                    "sample": "James",
+                    "forbiddenSymbols": [
+                      "(",
+                      ")",
+                      "{",
+                      "}"
+                    ]
+                  },
+                  "placeholder": "Last Name"
+                },
+                {
+                  "component": "TEXT",
+                  "fieldId": "company",
+                  "personField": "267ce64a-1a26-4326-9036-6384696f39c8",
+                  "label": "Company",
+                  "isRequired": false,
+                  "isHidden": false,
+                  "additionalConfiguration": {},
+                  "validationRules": {
+                    "maxLength": 1000,
+                    "sample": "Lorem ipsum"
+                  },
+                  "placeholder": "Company"
+                },
+                {
+                  "component": "EMAIL",
+                  "fieldId": "email",
+                  "personField": "email",
+                  "label": "Email Address",
+                  "isRequired": true,
+                  "isHidden": false,
+                  "additionalConfiguration": {},
+                  "validationRules": {
+                    "maxLength": 1000,
+                    "pattern": "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\\\.[A-Z|a-z]{2,}",
+                    "sample": "email@example.com"
+                  },
+                  "placeholder": "Email"
+                },
+                {
+                  "component": "TEXTAREA",
+                  "fieldId": "business_needs",
+                  "label": "Business Needs",
+                  "isRequired": false,
+                  "isHidden": false,
+                  "additionalConfiguration": {},
+                  "validationRules": {
+                    "maxLength": 3000,
+                    "sample": "Lorem ipsum ..."
+                  },
+                  "placeholder": ""
+                }
+              ],
+              "createdAt": "2022-07-11T06:38:12.757+0000",
+              "updatedAt": "2022-07-11T06:45:12.826+0000",
+              "resubmitEnabled": true,
+              "formType": "OPT_IN",
+              "formStatus": "ACTIVE"
+            }    
+          ],
+          "offset": 0,
+          "limit": 25,
+          "total": 1
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $formsApi = new FormsApi($this->getConfiguration(), client: $client);
+
+        $expectedPath = '/forms/1/forms?'
+            . Query::build([
+                'offset' => 0,
+                'limit' => 25,
+                'formType' => 'OPT_IN',
+                'formStatus' => 'ACTIVE',
+            ]);
+
+        $closures = [
+            fn () => $formsApi->getForms(formType: FormsType::OPT_IN(), formStatus: FormsStatus::ACTIVE()),
+            fn () => $formsApi->getFormsAsync(formType: FormsType::OPT_IN(), formStatus: FormsStatus::ACTIVE()),
+        ];
+
+        $expectedResponse = new FormsResponse(
+            forms: [
+                new FormsResponseContent(
+                    id: 'f23f0f7c-9898-4feb-8f21-5afe2c29db7e',
+                    name: 'Test form',
+                    elements: [
+                        new FormsElement(
+                            component: 'TEXT',
+                            fieldId: 'first_name',
+                            personField: 'firstName',
+                            label: 'First Name',
+                            isRequired: false,
+                            isHidden: false,
+                            additionalConfiguration: [],
+                            validationRules: new FormsValidationRules(
+                                maxLength: 255,
+                                sample: 'James',
+                                forbiddenSymbols: ['^', '&', '<', '>']
+                            ),
+                            placeholder: 'First Name'
+                        ),
+                        new FormsElement(
+                            component: 'TEXT',
+                            fieldId: 'last_name',
+                            personField: 'lastName',
+                            label: 'Last Name',
+                            isRequired: false,
+                            isHidden: false,
+                            additionalConfiguration: [],
+                            validationRules: new FormsValidationRules(
+                                maxLength: 255,
+                                sample: 'James',
+                                forbiddenSymbols: ['(', ')', '{', '}']
+                            ),
+                            placeholder: 'Last Name'
+                        ),
+                        new FormsElement(
+                            component: 'TEXT',
+                            fieldId: 'company',
+                            personField: '267ce64a-1a26-4326-9036-6384696f39c8',
+                            label: 'Company',
+                            isRequired: false,
+                            isHidden: false,
+                            additionalConfiguration: [],
+                            validationRules: new FormsValidationRules(
+                                maxLength: 1000,
+                                sample: 'Lorem ipsum'
+                            ),
+                            placeholder: 'Company'
+                        ),
+                        new FormsElement(
+                            component: 'EMAIL',
+                            fieldId: 'email',
+                            personField: 'email',
+                            label: 'Email Address',
+                            isRequired: true,
+                            isHidden: false,
+                            additionalConfiguration: [],
+                            validationRules: new FormsValidationRules(
+                                maxLength: 1000,
+                                pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}',
+                                sample: 'email@example.com'
+                            ),
+                            placeholder: 'Email'
+                        ),
+                        new FormsElement(
+                            component: 'TEXTAREA',
+                            fieldId: 'business_needs',
+                            label: 'Business Needs',
+                            isRequired: false,
+                            isHidden: false,
+                            additionalConfiguration: [],
+                            validationRules: new FormsValidationRules(
+                                maxLength: 3000,
+                                sample: 'Lorem ipsum ...'
+                            ),
+                            placeholder: ''
+                        )
+                    ],
+                    resubmitEnabled: true,
+                    formType: FormsType::OPT_IN(),
+                    formStatus: FormsStatus::ACTIVE(),
+                    createdAt: new DateTime('2022-07-11T06:38:12.757+0000'),
+                    updatedAt: new DateTime('2022-07-11T06:45:12.826+0000')
+                )
+            ],
+            offset: 0,
+            limit: 25,
+            total: 1
+        );
+
+        $this->assertGetRequest(
+            $closures,
+            $expectedPath,
+            $expectedResponse,
+            $requestHistoryContainer
+        );
+    }
+
+    public function testGetForm()
+    {
+        $givenResponse = <<<JSON
+        {
+          "id": "f23f0f7c-9898-4feb-8f21-5afe2c29db7e",
+          "name": "Test form",
+          "elements": [
+            {
+              "component": "TEXT",
+              "fieldId": "company",
+              "personField": "267ce64a-1a26-4326-9036-6384696f39c8",
+              "label": "Company",
+              "isRequired": false,
+              "isHidden": false,
+              "additionalConfiguration": {},
+              "validationRules": {
+                "maxLength": 1000,
+                "sample": "Lorem ipsum"
+              },
+              "placeholder": "Company"
+            },
+            {
+              "component": "TEXTAREA",
+              "fieldId": "business_needs",
+              "label": "Business Needs",
+              "isRequired": false,
+              "isHidden": false,
+              "additionalConfiguration": {
+                "config": true
+              },
+              "validationRules": {
+                "maxLength": 3000,
+                "sample": "Lorem ipsum ..."
+              },
+              "placeholder": ""
+            }
+          ],
+          "createdAt": "2022-07-11T06:38:12.757+0000",
+          "updatedAt": "2022-07-11T06:45:12.826+0000",
+          "resubmitEnabled": true,
+          "formType": "OPT_IN",
+          "formStatus": "ACTIVE"
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $formsApi = new FormsApi($this->getConfiguration(), client: $client);
+        $expectedPath = '/forms/1/forms/f23f0f7c-9898-4feb-8f21-5afe2c29db7e';
+
+        $closures = [
+            fn () => $formsApi->getForm('f23f0f7c-9898-4feb-8f21-5afe2c29db7e'),
+            fn () => $formsApi->getFormAsync('f23f0f7c-9898-4feb-8f21-5afe2c29db7e'),
+        ];
+
+        $expectedResponse = new FormsResponseContent(
+            id: 'f23f0f7c-9898-4feb-8f21-5afe2c29db7e',
+            name: 'Test form',
+            elements: [
+                new FormsElement(
+                    component: 'TEXT',
+                    fieldId: 'company',
+                    personField: '267ce64a-1a26-4326-9036-6384696f39c8',
+                    label: 'Company',
+                    isRequired: false,
+                    isHidden: false,
+                    additionalConfiguration: [],
+                    validationRules: new FormsValidationRules(
+                        maxLength: 1000,
+                        sample: 'Lorem ipsum'
+                    ),
+                    placeholder: 'Company'
+                ),
+                new FormsElement(
+                    component: 'TEXTAREA',
+                    fieldId: 'business_needs',
+                    label: 'Business Needs',
+                    isRequired: false,
+                    isHidden: false,
+                    additionalConfiguration: ['config' => true],
+                    validationRules: new FormsValidationRules(
+                        maxLength: 3000,
+                        sample: 'Lorem ipsum ...'
+                    ),
+                    placeholder: ''
+                )
+            ],
+            resubmitEnabled: true,
+            formType: FormsType::OPT_IN(),
+            formStatus: FormsStatus::ACTIVE(),
+            createdAt: new DateTime('2022-07-11T06:38:12.757+0000'),
+            updatedAt: new DateTime('2022-07-11T06:45:12.826+0000')
+        );
+
+        $this->assertGetRequest(
+            $closures,
+            $expectedPath,
+            $expectedResponse,
+            $requestHistoryContainer
+        );
+    }
+
+    public function testIncrementFormViewCount()
+    {
+        $givenResponse = <<<JSON
+        {
+          "status": "OK"
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $formsApi = new FormsApi($this->getConfiguration(), client: $client);
+        $expectedPath = '/forms/1/forms/cec5dfd2-4238-48e0-933b-9acbdb2e6f5fe/views';
+
+        $closures = [
+            fn () => $formsApi->incrementViewCount('cec5dfd2-4238-48e0-933b-9acbdb2e6f5fe'),
+            fn () => $formsApi->incrementViewCountAsync('cec5dfd2-4238-48e0-933b-9acbdb2e6f5fe'),
+        ];
+
+        $expectedResponse = new FormsStatusResponse(
+            status: 'OK'
+        );
+
+        $this->assertPostRequestWithNoBody(
+            $closures,
+            $expectedPath,
+            $expectedResponse,
+            $requestHistoryContainer
+        );
+    }
+
+    public function testSubmitFormData()
+    {
+        $givenRequest = <<<JSON
+        {
+          "first_name": "John",
+          "last_name": "Doe",
+          "company": "Infobip",
+          "email": "info@example.com"
+        }
+        JSON;
+
+        $givenResponse = <<<JSON
+        {
+          "status": "OK"
+        }
+        JSON;
+
+        $requestHistoryContainer = [];
+        $responses = $this->makeResponses(2, $givenResponse, 200);
+        $client = $this->mockClient($responses, $requestHistoryContainer);
+
+        $formsApi = new FormsApi($this->getConfiguration(), client: $client);
+        $expectedPath = '/forms/1/forms/f7cf1606-e155-40eb-9721-78183d268d24/data';
+
+        $request = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'company' => 'Infobip',
+            'email' => 'info@example.com'
+        ];
+
+        $closures = [
+            fn () => $formsApi->submitFormData(
+                'f7cf1606-e155-40eb-9721-78183d268d24',
+                $request,
+                "mySource"
+            ),
+            fn () => $formsApi->submitFormDataAsync(
+                'f7cf1606-e155-40eb-9721-78183d268d24',
+                $request,
+                "mySource"
+            )
+        ];
+
+        $expectedResponse = new FormsStatusResponse(
+            status: 'OK'
+        );
+
+        $this->assertPostRequestWithAdditionalHeaders(
+            $closures,
+            $expectedPath,
+            $givenRequest,
+            $expectedResponse,
+            $requestHistoryContainer,
+            ['ib-submission-source' => 'mySource']
+        );
+    }
+}

--- a/Test/Api/WhatsApp/Fixtures/TemplateGetFixture.php
+++ b/Test/Api/WhatsApp/Fixtures/TemplateGetFixture.php
@@ -25,7 +25,9 @@ $responseVars = [
                 'body' => ['text' => 'some body text {{1}}'],
                 'footer' => ['text' => 'some footer text'],
                 'type' => WhatsAppTextHeaderApiData::FORMAT
-            ]
+            ],
+            'createdAt' => '2024-01-01T00:00:00.000+0000',
+            'lastUpdatedAt' => '2024-01-01T00:00:00.000+0000'
         ]
     ]
 ];

--- a/Test/Api/WhatsApp/ManageWhatsAppApiTest.php
+++ b/Test/Api/WhatsApp/ManageWhatsAppApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Infobip\Test\Api\WhatsApp;
 
+use DateTime;
 use GuzzleHttp\Psr7\Query;
 use Infobip\Api\WhatsAppApi as ManageWhatsAppApi;
 use Infobip\Model\WhatsAppBodyApiData;
@@ -1007,6 +1008,15 @@ class ManageWhatsAppApiTest extends ApiTestBase
             $this->assertEquals(
                 $templateResponse['structure']['type'],
                 $sendResponse->getStructure()->getType()
+            );
+
+            $this->assertEquals(
+                new DateTime($templateResponse['createdAt']),
+                $sendResponse->getCreatedAt()
+            );
+            $this->assertEquals(
+                new DateTime($templateResponse['lastUpdatedAt']),
+                $sendResponse->getLastUpdatedAt()
             );
         }
     }

--- a/Test/ObjectSerializerTest.php
+++ b/Test/ObjectSerializerTest.php
@@ -6,10 +6,10 @@ namespace Infobip\Test;
 
 use DateTime;
 use Infobip\ObjectSerializer;
-use PHPUnit\Framework\TestCase;
 use Infobip\Test\Inheritance\ModelChild1;
 use Infobip\Test\Inheritance\ModelChild2;
 use Infobip\Test\Inheritance\ModelSuper;
+use PHPUnit\Framework\TestCase;
 
 class ObjectSerializerTest extends TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "infobip/infobip-api-php-client",
     "description": "PHP library for consuming Infobip's API",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "keywords": [
         "infobip",
         "sms",

--- a/moments.md
+++ b/moments.md
@@ -1,0 +1,109 @@
+# Moments quickstart
+
+This quick guide aims to help you start with [Infobip Moments API](https://www.infobip.com/docs/api/customer-engagement/moments).    
+
+Initialize configuration:
+
+```php
+$configuration = new Configuration(
+    host: 'your-base-url',
+    apiKey: 'your-api-key'
+);
+```
+
+## Flow API
+
+You can now create an instance of `FlowApi` which allows you to manage your flows.
+
+```php
+$flowApi = new FlowApi(config: $configuration);
+```
+### Add participants to flow
+
+To add participants to a flow, you can use the following code:
+
+```php
+$campaignId = '200000000000001';
+
+$request = new FlowAddFlowParticipantsRequest(
+    participants: [
+        new FlowParticipant(
+            identifyBy: new FlowPersonUniqueField(
+                identifier: 'test@example.com',
+                type: FlowPersonUniqueFieldType::EMAIL
+            ),
+            variables: ['orderNumber' => 1167873391]
+        )
+    ],
+    notifyUrl: 'https://example.com/callback',
+);
+
+$status = $flowApi->addFlowParticipants($campaignId, $request);
+```
+
+The received status will contain the operation ID that you can use to track the status of the operation.
+
+### Get a report on participants added to flow
+
+To fetch a report to confirm that all persons have been successfully added to the flow, you can use the following code:
+
+```php
+$report = $flowApi->getFlowParticipantsAddedReport($campaignId, $status->getOperationId());
+```
+
+### Remove person from flow
+
+To remove a person from a flow, you can use the following code:
+
+```php
+$externalId = '8edb24b5-0319-48cd-a1d9-1e8bc5d577ab';
+$flowApi->removePeopleFromFlow($campaignId, null, null, $externalId);
+```
+
+## Forms API
+
+You can now create an instance of `FormsApi` which allows you to manage your forms.
+
+```php
+$formsApi formsApi = new FormsApi(config: $configuration);
+```
+
+### Get forms
+
+To get all your forms, you can use the following code:
+
+```php
+$formsResponse = $formsApi->getForms();
+```
+
+### Get form by ID
+
+To get a specific form by its ID, you can use the following code:
+
+```php
+$formId = 'cec5dfd2-4238-48e0-933b-9acbdb2e6f5f';
+$formResponse = $formsApi->getForm($formId);
+```
+
+### Increment form view count
+
+To increase the view counter of a specific form, you can use the following code:
+
+```php
+$status = $formsApi->incrementViewCount($formId);
+```
+
+### Submit form data
+
+To submit data to a specific form, you can use the following code:
+
+```php
+$data = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'company' => 'Infobip',
+    'email' => 'info@example.com'
+];
+
+$status = $formsApi->submitFormData($formId, $data);
+```


### PR DESCRIPTION
## [ [6.1.0](https://github.com/infobip/infobip-api-php-client/releases/tag/6.1.0) ] - 2024-12-16

### Added
* Support for [Infobip Moments](https://www.infobip.com/docs/api/customer-engagement/moments).

### Changed
* Removed no longer supported 50 business-initiated conversations messaging tear limit for WhatsApp senders.
* Added `createdAt` and `lastUpdatedAt` fields to WhatsApp Template response models.
* Added new Calls error code type: `MACHINE_DETECTED`.
* `CallRoutingWebRtcEndpoint` now allows using default `to` value used in inbound call as an identity.
* Refactored a part of Calls API tests.

### Fixed
* IVR scenario action scripts types.